### PR TITLE
drop redundant deref on RefMut in run_thread

### DIFF
--- a/src/vm/interp.rs
+++ b/src/vm/interp.rs
@@ -242,7 +242,7 @@ pub(crate) fn run_thread<'gc>(ctx: Context<'gc>, thread: Thread<'gc>) -> Result<
     };
     let registers = unsafe { ts.stack.as_mut_ptr().add(base) };
     let handlers = HANDLERS.as_ptr() as *const ();
-    op_nop(Instruction::NOP, ctx, &mut *ts, registers, ip, handlers)
+    op_nop(Instruction::NOP, ctx, &mut ts, registers, ip, handlers)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes the explicit `*` in `&mut *ts` at `src/vm/interp.rs` since `RefMut` deref-coerces to `&mut ThreadState` automatically when passed to `op_nop`.
- Silences the `clippy::explicit_auto_deref` warning called out in #24.

Closes #24

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy` no longer reports `explicit_auto_deref` for this site