### PR TITLE
lexer: accept all Lua 5.5 hex numeral forms

### DIFF
--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -399,6 +399,51 @@ mod tests {
         lua.execute::<i64>(&ex).expect("run")
     }
 
+    fn run_returning_float(src: &str) -> f64 {
+        let mut lua = Lua::new();
+        let ex = lua
+            .try_enter(|ctx| -> Result<_, LoadError> {
+                let chunk = ctx.load(src, Some("test"))?;
+                Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+            })
+            .expect("load");
+        lua.execute::<f64>(&ex).expect("run")
+    }
+
+    #[test]
+    fn hex_numeral_literals() {
+        // Issue #99: the lexer rejected several valid Lua 5.5 hex numerals at
+        // chunk-load time. `.expect("load")` inside the helpers guards the
+        // original symptom (a parse error); the values are cross-checked
+        // against lua5.5. All are exact dyadic rationals, so `==` is safe.
+
+        // Unsigned binary exponent.
+        assert_eq!(run_returning_float("return 0x1p4"), 16.0);
+        // Fractional part with an unsigned exponent.
+        assert_eq!(run_returning_float("return 0x1.8p0"), 1.5);
+        // Uppercase 0X prefix with a fractional part.
+        assert_eq!(run_returning_float("return 0X1.8"), 1.5);
+        // Leading radix point (no digit before the `.`).
+        assert_eq!(run_returning_float("return 0x.8"), 0.5);
+        // Leading radix point plus a signed exponent.
+        assert_eq!(run_returning_float("return 0x.8p+1"), 1.0);
+        // Trailing radix point (no digit after the `.`).
+        assert_eq!(run_returning_float("return 0x1."), 1.0);
+        // Uppercase prefix + leading dot + uppercase exponent mark.
+        assert_eq!(run_returning_float("return 0X.8P-2"), 0.125);
+        // The binary exponent is DECIMAL: `p10` is 2^10, not 2^16.
+        assert_eq!(run_returning_float("return 0x1p10"), 1024.0);
+
+        // Uppercase 0X prefix with no `.`/exponent stays an integer literal.
+        assert_eq!(run_returning_int("return 0X10"), 16);
+
+        // Regression guards for forms that already lexed.
+        assert_eq!(run_returning_float("return 0x1p+4"), 16.0);
+        assert_eq!(run_returning_float("return 0x1.9p-3"), 0.1953125);
+        assert_eq!(run_returning_float("return 0xce.1"), 206.0625);
+        assert_eq!(run_returning_int("return 0xFF"), 255);
+    }
+
     #[test]
     fn local_call_inside_native_call() {
         // Direct repro of the register-clobber bug: `probe(f(5))` where `f` is

--- a/src/parser/kind.rs
+++ b/src/parser/kind.rs
@@ -203,13 +203,18 @@ pub enum SyntaxKind {
     #[regex(r"[0-9]+", priority = 3)]
     Int,
 
-    #[regex(r"0x[0-9a-fA-F]+", priority = 7)]
+    #[regex(r"0[xX][0-9a-fA-F]+", priority = 7)]
     HexInt,
 
     #[regex(r"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?")]
     Float,
 
-    #[regex(r"0x[0-9a-fA-F]+(\.[0-9a-fA-F]+)?([pP][+-][0-9a-fA-F]+)?")]
+    // Lua 5.5 hex float: `0[xX]`, then a mantissa that must carry a `.` or a
+    // binary exponent (else it's a HexInt). Each branch keeps >=1 hex digit:
+    // `digits.digits?` (trailing `.` ok), `.digits`, or `digits` with a
+    // mandatory exponent. The exponent is a DECIMAL integer with an OPTIONAL
+    // sign (`0x1p4` == 16.0); hex digits in the exponent are malformed.
+    #[regex(r"0[xX]([0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+)?|\.[0-9a-fA-F]+([pP][+-]?[0-9]+)?|[0-9a-fA-F]+[pP][+-]?[0-9]+)")]
     HexFloat,
 
     #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", priority = 3)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -90,6 +90,7 @@ mod tests {
     test!(if, "test-files/if.lua");
     test!(jens, "test-files/jens.lua");
     test!(literal, "test-files/literal.lua");
+    test!(hex_numeral, "test-files/hex_numeral.lua");
     test!(nbody, "test-files/nbody.lua");
     test!(op_prec, "test-files/op_prec.lua");
     test!(primes, "test-files/primes.lua");

--- a/src/parser/snapshots/tcvm__parser__tests__parse_hex_numeral.snap
+++ b/src/parser/snapshots/tcvm__parser__tests__parse_hex_numeral.snap
@@ -1,0 +1,93 @@
+---
+source: src/parser/mod.rs
+expression: syntax_tree
+---
+Root@0..83
+  AssignStmt@0..7
+    AssignList@0..1
+      Ident@0..1
+        Ident@0..1 "a"
+    Assign@1..2 "="
+    ExprList@2..7
+      LiteralExpr@2..7
+        HexFloat@2..7 "0x1p4"
+  AssignStmt@7..16
+    AssignList@7..8
+      Ident@7..8
+        Ident@7..8 "b"
+    Assign@8..9 "="
+    ExprList@9..16
+      LiteralExpr@9..16
+        HexFloat@9..16 "0x1.8p0"
+  AssignStmt@16..22
+    AssignList@16..17
+      Ident@16..17
+        Ident@16..17 "c"
+    Assign@17..18 "="
+    ExprList@18..22
+      LiteralExpr@18..22
+        HexInt@18..22 "0X10"
+  AssignStmt@22..29
+    AssignList@22..23
+      Ident@22..23
+        Ident@22..23 "d"
+    Assign@23..24 "="
+    ExprList@24..29
+      LiteralExpr@24..29
+        HexFloat@24..29 "0X1.8"
+  AssignStmt@29..35
+    AssignList@29..30
+      Ident@29..30
+        Ident@29..30 "e"
+    Assign@30..31 "="
+    ExprList@31..35
+      LiteralExpr@31..35
+        HexFloat@31..35 "0x.8"
+  AssignStmt@35..44
+    AssignList@35..36
+      Ident@35..36
+        Ident@35..36 "f"
+    Assign@36..37 "="
+    ExprList@37..44
+      LiteralExpr@37..44
+        HexFloat@37..44 "0x.8p+1"
+  AssignStmt@44..50
+    AssignList@44..45
+      Ident@44..45
+        Ident@44..45 "g"
+    Assign@45..46 "="
+    ExprList@46..50
+      LiteralExpr@46..50
+        HexFloat@46..50 "0x1."
+  AssignStmt@50..59
+    AssignList@50..51
+      Ident@50..51
+        Ident@50..51 "h"
+    Assign@51..52 "="
+    ExprList@52..59
+      LiteralExpr@52..59
+        HexFloat@52..59 "0X.8P-2"
+  AssignStmt@59..67
+    AssignList@59..60
+      Ident@59..60
+        Ident@59..60 "i"
+    Assign@60..61 "="
+    ExprList@61..67
+      LiteralExpr@61..67
+        HexFloat@61..67 "0x1p+4"
+  AssignStmt@67..77
+    AssignList@67..68
+      Ident@67..68
+        Ident@67..68 "j"
+    Assign@68..69 "="
+    ExprList@69..77
+      LiteralExpr@69..77
+        HexFloat@69..77 "0x1.9p-3"
+  AssignStmt@77..83
+    AssignList@77..78
+      Ident@77..78
+        Ident@77..78 "k"
+    Assign@78..79 "="
+    ExprList@79..83
+      LiteralExpr@79..83
+        HexInt@79..83 "0xFF"

--- a/test-files/hex_numeral.lua
+++ b/test-files/hex_numeral.lua
@@ -1,0 +1,13 @@
+-- Hex numeral forms from issue #99. Each previously failed to lex.
+a = 0x1p4        -- unsigned binary exponent
+b = 0x1.8p0      -- frac + unsigned exponent
+c = 0X10         -- uppercase 0X prefix (integer)
+d = 0X1.8        -- uppercase 0X prefix (float)
+e = 0x.8         -- leading radix point
+f = 0x.8p+1      -- leading radix point + signed exponent
+g = 0x1.         -- trailing radix point
+h = 0X.8P-2      -- uppercase prefix, leading dot, uppercase exponent
+-- Regression guards: forms that already lexed must keep working.
+i = 0x1p+4       -- signed exponent
+j = 0x1.9p-3     -- frac + signed exponent
+k = 0xFF         -- plain hex integer


### PR DESCRIPTION
Fixes #99.

The `HexInt`/`HexFloat` token regexes were narrower than the Lua 5.5 grammar, so valid hex literals were rejected at chunk-load time. Widened them to accept:

- uppercase `0X` prefix (`0X10`, `0X1.8`)
- leading radix point (`0x.8`, `0x.8p+1`) and trailing radix point (`0x1.`)
- an **optionally signed, decimal** binary exponent (`0x1p4`); previously the exponent required a `+`/`-` sign and wrongly allowed hex digits

`HexFloat` now requires a `.` or an exponent, so it never competes with `HexInt`. Output verified byte-for-byte against `lua5.5`, including a 420-case differential fuzz over prefix × mantissa × exponent combinations (0 mismatches on acceptance and value).

Tests: end-to-end value checks in `src/lua/mod.rs::hex_numeral_literals` and a parser snapshot (`test-files/hex_numeral.lua`) pinning the token classification.
