### PR TITLE
lexer: accept decimal floats with leading/trailing radix point

### DIFF
--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -445,6 +445,32 @@ mod tests {
     }
 
     #[test]
+    fn decimal_numeral_literals() {
+        // The lexer rejected decimal floats with a leading or trailing radix
+        // point. `.expect("load")` guards the original symptom (a parse error);
+        // values are cross-checked against lua5.5. Each decimal-to-f64
+        // conversion rounds the same way in Rust and Lua, so `==` is exact.
+
+        // Leading radix point.
+        assert_eq!(run_returning_float("return .5"), 0.5);
+        // Trailing radix point.
+        assert_eq!(run_returning_float("return 1."), 1.0);
+        assert_eq!(run_returning_float("return 5."), 5.0);
+        // Leading radix point + exponent.
+        assert_eq!(run_returning_float("return .5e2"), 50.0);
+        // Trailing radix point + exponent.
+        assert_eq!(run_returning_float("return 1.e5"), 100000.0);
+        // Leading radix point, zero fraction.
+        assert_eq!(run_returning_float("return .0"), 0.0);
+        assert_eq!(run_returning_float("return .5E-2"), 0.005);
+
+        // Regression guards for forms that already lexed.
+        assert_eq!(run_returning_float("return 1.5"), 1.5);
+        assert_eq!(run_returning_float("return 1e5"), 100000.0);
+        assert_eq!(run_returning_float("return 3.14"), 3.14);
+    }
+
+    #[test]
     fn local_call_inside_native_call() {
         // Direct repro of the register-clobber bug: `probe(f(5))` where `f` is
         // a low-register local and `probe` is a global. Before the fix, the

--- a/src/parser/kind.rs
+++ b/src/parser/kind.rs
@@ -206,7 +206,11 @@ pub enum SyntaxKind {
     #[regex(r"0[xX][0-9a-fA-F]+", priority = 7)]
     HexInt,
 
-    #[regex(r"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?")]
+    // Lua 5.5 decimal float: a mantissa that must carry a `.` or an exponent
+    // (else it's an Int). Each branch keeps >=1 digit: `digits.digits?`
+    // (trailing `.` ok), `.digits` (leading `.` ok), or `digits` with a
+    // mandatory exponent.
+    #[regex(r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?|\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+")]
     Float,
 
     // Lua 5.5 hex float: `0[xX]`, then a mantissa that must carry a `.` or a

--- a/src/parser/machinery.rs
+++ b/src/parser/machinery.rs
@@ -111,7 +111,11 @@ impl<'cache, 'source> State<'cache, 'source> {
     pub fn error_eat_until(&mut self, one_of: &[SyntaxKind]) -> Span {
         let marker = self.start(T![invalid]);
         let mut last_span = self.span();
-        while !one_of.contains(&self.at()) {
+        // Stop at EOF even when it isn't a recovery token, or the loop would
+        // bump past the end of the stream and `span()` would index out of
+        // bounds. Reachable on any malformed tail with no recovery token
+        // before EOF (e.g. `1.2.3`, `foo @ bar`).
+        while self.at() != T![eof] && !one_of.contains(&self.at()) {
             self.bump();
             last_span = self.span();
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -91,6 +91,7 @@ mod tests {
     test!(jens, "test-files/jens.lua");
     test!(literal, "test-files/literal.lua");
     test!(hex_numeral, "test-files/hex_numeral.lua");
+    test!(decimal_numeral, "test-files/decimal_numeral.lua");
     test!(nbody, "test-files/nbody.lua");
     test!(op_prec, "test-files/op_prec.lua");
     test!(primes, "test-files/primes.lua");
@@ -116,4 +117,22 @@ mod tests {
     test!(global_star_nested, "test-files/global_star_nested.lua");
     test!(global_const_star, "test-files/global_const_star.lua");
     test!(vararg_param, "test-files/vararg_param.lua");
+
+    // A malformed tail with no statement-recovery token before EOF (e.g. the
+    // adjacent `Float Float` from `1.2.3` / `10..20`) must yield a parse error
+    // report, not run the recovery loop past EOF and panic.
+    #[test]
+    fn malformed_numeral_reports_without_panic() {
+        for src in [
+            "1.2.3",
+            "x = 10..20",
+            "print(.5.5)",
+            "y = 0x1.2.3",
+            "foo @ bar",
+        ] {
+            let mut cache = NodeCache::new();
+            let (_tree, reports) = parse(&mut cache, src);
+            assert!(!reports.is_empty(), "expected a parse error for {src:?}");
+        }
+    }
 }

--- a/src/parser/snapshots/tcvm__parser__tests__parse_decimal_numeral.snap
+++ b/src/parser/snapshots/tcvm__parser__tests__parse_decimal_numeral.snap
@@ -1,0 +1,85 @@
+---
+source: src/parser/mod.rs
+expression: syntax_tree
+---
+Root@0..51
+  AssignStmt@0..4
+    AssignList@0..1
+      Ident@0..1
+        Ident@0..1 "a"
+    Assign@1..2 "="
+    ExprList@2..4
+      LiteralExpr@2..4
+        Float@2..4 ".5"
+  AssignStmt@4..8
+    AssignList@4..5
+      Ident@4..5
+        Ident@4..5 "b"
+    Assign@5..6 "="
+    ExprList@6..8
+      LiteralExpr@6..8
+        Float@6..8 "1."
+  AssignStmt@8..14
+    AssignList@8..9
+      Ident@8..9
+        Ident@8..9 "c"
+    Assign@9..10 "="
+    ExprList@10..14
+      LiteralExpr@10..14
+        Float@10..14 ".5e2"
+  AssignStmt@14..20
+    AssignList@14..15
+      Ident@14..15
+        Ident@14..15 "d"
+    Assign@15..16 "="
+    ExprList@16..20
+      LiteralExpr@16..20
+        Float@16..20 "1.e5"
+  AssignStmt@20..24
+    AssignList@20..21
+      Ident@20..21
+        Ident@20..21 "e"
+    Assign@21..22 "="
+    ExprList@22..24
+      LiteralExpr@22..24
+        Float@22..24 ".0"
+  AssignStmt@24..28
+    AssignList@24..25
+      Ident@24..25
+        Ident@24..25 "f"
+    Assign@25..26 "="
+    ExprList@26..28
+      LiteralExpr@26..28
+        Float@26..28 "5."
+  AssignStmt@28..33
+    AssignList@28..29
+      Ident@28..29
+        Ident@28..29 "g"
+    Assign@29..30 "="
+    ExprList@30..33
+      LiteralExpr@30..33
+        Float@30..33 "1.5"
+  AssignStmt@33..38
+    AssignList@33..34
+      Ident@33..34
+        Ident@33..34 "h"
+    Assign@34..35 "="
+    ExprList@35..38
+      LiteralExpr@35..38
+        Float@35..38 "1e5"
+  AssignStmt@38..45
+    AssignList@38..39
+      Ident@38..39
+        Ident@38..39 "i"
+    Assign@39..40 "="
+    ExprList@40..45
+      LiteralExpr@40..45
+        Float@40..45 "0.5e5"
+  AssignStmt@45..51
+    AssignList@45..46
+      Ident@45..46
+        Ident@45..46 "j"
+    Assign@46..47 "="
+    ExprList@47..51
+      LiteralExpr@47..51
+        Float@47..51 "3.14"

--- a/test-files/decimal_numeral.lua
+++ b/test-files/decimal_numeral.lua
@@ -1,0 +1,13 @@
+-- Decimal numeral forms with a leading or trailing radix point. The leading
+-- and trailing `.` variants previously failed to lex as a single Float.
+a = .5          -- leading radix point
+b = 1.          -- trailing radix point
+c = .5e2        -- leading radix point + exponent
+d = 1.e5        -- trailing radix point + exponent
+e = .0          -- leading radix point, zero frac
+f = 5.          -- trailing radix point
+-- Regression guards: forms that already lexed must keep working.
+g = 1.5         -- digits on both sides
+h = 1e5         -- exponent, no radix point
+i = 0.5e5       -- digits + exponent
+j = 3.14        -- plain float


### PR DESCRIPTION
Follow-up to #100 (the hex-numeral fix), addressing the decimal analog noted there.

Lua 5.5 accepts decimal floats with a leading or trailing radix point, but the `Float` token regex required a digit on both sides of the `.`, so these were rejected at chunk-load time:

```
.5      -> 0.5
1.      -> 1.0
1.e5    -> 100000.0
.5e2    -> 50.0
```

The regex is rewritten to the full grammar (mirroring the hex-float branch structure): a mantissa that must carry a `.` or an exponent, with `>=1` digit kept in every branch. Verified byte-for-byte against `lua5.5`, including a ~200-case differential fuzz (0 mismatches on acceptance and value).

### Also: harden statement error-recovery against running past EOF

The wider grammar lexes malformed tails like `10..20` and `1.2.3` as **adjacent `Float` tokens** (matching Lua, which also rejects them), which routes them into `error_eat_until`. That loop only stopped on a recovery token, so with no recovery token before EOF it bumped past the end of the stream and panicked with an index-out-of-bounds.

This is a **pre-existing latent panic** — reachable on `main` via any malformed tail, e.g. `foo @ bar` — that the wider numeral grammar makes easy to hit. Added an EOF guard so the library now returns a clean parse error instead of crashing. (The `tcvm-cli` dev tool still `.unwrap()`s load errors for *all* syntax errors; that's unchanged and out of scope.)

### Tests
- `test-files/decimal_numeral.lua` + snapshot — pins the leading/trailing-dot forms lexing as single `Float` tokens.
- `lua::tests::decimal_numeral_literals` — end-to-end value checks vs lua5.5.
- `parser::tests::malformed_numeral_reports_without_panic` — `1.2.3`/`10..20`/`foo @ bar` produce a parse error report instead of panicking.

Full suite green.
