### PR TITLE
vm: floor division with a float operand returns a float

### DIFF
--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -444,6 +444,41 @@ mod tests {
         assert_eq!(run_returning_int("return 0xFF"), 255);
     }
 
+    fn run_with_stdlib_bool(src: &str) -> bool {
+        let mut lua = Lua::new();
+        lua.load_all();
+        let ex = lua
+            .try_enter(|ctx| -> Result<_, LoadError> {
+                let chunk = ctx.load(src, Some("test"))?;
+                Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+            })
+            .expect("load");
+        lua.execute::<bool>(&ex).expect("run")
+    }
+
+    #[test]
+    fn floor_div_with_float_operand_is_float() {
+        // `//` with any float operand returns a float (Lua: `floor(a/b)`), not
+        // an integer. Type checked via `math.type`; values cross-checked
+        // against lua5.5. The `1e300` case guards the old `as i64` cast, which
+        // saturated the quotient to i64::MAX.
+        assert!(run_with_stdlib_bool(
+            "return math.type(16.0 // 2) == 'float'"
+        ));
+        assert!(run_with_stdlib_bool(
+            "return math.type(16 // 2.0) == 'float'"
+        ));
+        assert!(run_with_stdlib_bool("return 16.0 // 2 == 8.0"));
+        assert!(run_with_stdlib_bool("return 7.5 // 2 == 3.0"));
+        assert!(run_with_stdlib_bool("return -7.0 // 2 == -4.0"));
+        assert!(run_with_stdlib_bool("return 1e300 // 1 == 1e300"));
+        // Integer `//` is unaffected: still an integer.
+        assert!(run_with_stdlib_bool(
+            "return math.type(16 // 2) == 'integer'"
+        ));
+        assert!(run_with_stdlib_bool("return 16 // 2 == 8"));
+    }
+
     #[test]
     fn local_call_inside_native_call() {
         // Direct repro of the register-clobber bug: `probe(f(5))` where `f` is

--- a/src/vm/num.rs
+++ b/src/vm/num.rs
@@ -166,7 +166,9 @@ impl ArithOp for IDiv {
 
     #[inline(always)]
     fn float<'gc>(lhs: f64, rhs: f64) -> Value<'gc> {
-        Value::integer((lhs / rhs).floor() as i64)
+        // Lua's `//` on floats is `floor(a/b)` and stays a float — keep the
+        // float type (and inf/nan; `as i64` would saturate large quotients).
+        Value::float((lhs / rhs).floor())
     }
 }
 


### PR DESCRIPTION
Second follow-up from #100's review notes.

Lua's `//` produces a float whenever either operand is a float (it computes `floor(a/b)` and keeps the float type). `IDiv::float` instead floored and cast to `i64`, returning an integer:

```
            tcvm    lua
16.0 // 2   8       8.0
16 // 2.0   8       8.0
7.5 // 2    3       3.0
-7.0 // 2   -4      -4.0
```

The `as i64` cast also corrupted the value for quotients outside `i64` range — `1e300 // 1` saturated to `i64::MAX` instead of `1e300`, and `inf`/`nan` were mangled. The fix returns the floored float directly (`Value::float((lhs / rhs).floor())`), matching Lua exactly. Integer `//` is untouched.

Verified against `lua5.5`: a 144-case differential over mixed int/float/sign operands (0 mismatches), plus inf/nan/div-by-zero and the `1e300` saturation case.

### Tests
`lua::tests::floor_div_with_float_operand_is_float` — asserts float-ness via `math.type`, checks values, guards the `1e300` saturation case, and confirms integer `//` still yields an integer. (Confirmed the test fails without the fix.)

### Out of scope (separate pre-existing bug)
Integer `7 // 0` and `7 % 0` panic in the VM (Rust `wrapping_div`/`wrapping_rem` by zero) instead of raising Lua's "attempt to perform 'n//0'" error. That's in the integer path, untouched here — worth its own fix.
