### PR TITLE
vm: raise instead of panicking on integer division/modulo by zero

### DIFF
--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -505,6 +505,47 @@ mod tests {
         assert_eq!(run_returning_float("return 3.14"), 3.14);
     }
 
+    fn run_expecting_error(src: &str) -> RuntimeError {
+        let mut lua = Lua::new();
+        let ex = lua
+            .try_enter(|ctx| -> Result<_, LoadError> {
+                let chunk = ctx.load(src, Some("test"))?;
+                Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+            })
+            .expect("load");
+        lua.execute::<i64>(&ex)
+            .expect_err("expected a runtime error")
+    }
+
+    #[test]
+    fn integer_div_mod_by_zero_raises() {
+        // Lua raises on integer `//` / `%` by a zero divisor. Previously this
+        // panicked the VM (`wrapping_div` / `wrapping_rem` by zero); now it
+        // surfaces as a runtime error like any other arithmetic failure.
+        for src in [
+            "return 7 // 0",
+            "return 0 // 0",
+            "return (-5) // 0",
+            "return 7 % 0",
+            "return (-5) % 0",
+        ] {
+            assert!(
+                matches!(run_expecting_error(src), RuntimeError::Opcode { .. }),
+                "expected a runtime error for {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn integer_div_mod_nonzero_still_works() {
+        // Regression guard: the zero-divisor check must not disturb the normal
+        // integer floor-div / modulo path (values per lua5.5).
+        assert_eq!(run_returning_int("return 7 // 2"), 3);
+        assert_eq!(run_returning_int("return (-7) // 2"), -4);
+        assert_eq!(run_returning_int("return 7 % 3"), 1);
+        assert_eq!(run_returning_int("return (-7) % 2"), 1);
+    }
+
     #[test]
     fn local_call_inside_native_call() {
         // Direct repro of the register-clobber bug: `probe(f(5))` where `f` is

--- a/src/vm/num.rs
+++ b/src/vm/num.rs
@@ -23,6 +23,14 @@ pub fn exact_float_to_int(f: f64) -> Option<i64> {
 #[inline(always)]
 pub fn op_arith<'gc, Op: ArithOp>(lhs: Value, rhs: Value) -> Option<Value<'gc>> {
     if let (Some(li), Some(ri)) = (lhs.get_integer(), rhs.get_integer()) {
+        // Lua raises on integer `//`/`%` by zero; without this guard the
+        // `wrapping_div`/`wrapping_rem` in `Op::int` would panic. Returning
+        // `None` takes the handler's error path (integers carry no metamethod),
+        // matching every other arithmetic error. Float `/0` is unaffected — it
+        // yields inf/nan down in the float branch.
+        if Op::INT_ZERO_DIVISOR_RAISES && ri == 0 {
+            return None;
+        }
         return Some(Op::int(li, ri));
     }
 
@@ -46,6 +54,10 @@ pub fn op_arith<'gc, Op: ArithOp>(lhs: Value, rhs: Value) -> Option<Value<'gc>> 
 }
 
 pub trait ArithOp {
+    /// `//` and `%` set this so `op_arith` raises on an integer zero divisor
+    /// instead of computing (and panicking in `wrapping_div`/`wrapping_rem`).
+    const INT_ZERO_DIVISOR_RAISES: bool = false;
+
     fn int<'gc>(lhs: i64, rhs: i64) -> Value<'gc>;
     fn float<'gc>(lhs: f64, rhs: f64) -> Value<'gc>;
 }
@@ -95,6 +107,8 @@ impl ArithOp for Mul {
 pub struct Mod;
 
 impl ArithOp for Mod {
+    const INT_ZERO_DIVISOR_RAISES: bool = true;
+
     #[inline(always)]
     fn int<'gc>(lhs: i64, rhs: i64) -> Value<'gc> {
         let r = lhs.wrapping_rem(rhs);
@@ -151,6 +165,8 @@ impl ArithOp for Div {
 pub struct IDiv;
 
 impl ArithOp for IDiv {
+    const INT_ZERO_DIVISOR_RAISES: bool = true;
+
     #[inline(always)]
     fn int<'gc>(lhs: i64, rhs: i64) -> Value<'gc> {
         let q = lhs.wrapping_div(rhs);


### PR DESCRIPTION
Third follow-up from #102's review notes.
