### PR TITLE
string: implement pattern engine (find, match, gmatch, gsub)

### DIFF
--- a/src/builtin/string/mod.rs
+++ b/src/builtin/string/mod.rs
@@ -1,11 +1,22 @@
+use std::cell::RefCell;
+
 use crate::Context;
 use crate::builtin::util;
 // `%d`/`%f` argument coercion reuses the shared `util` helpers so the
 // integer-representation and numeric-string rules (including `inf`/`nan`
 // rejection) match `tonumber`/`math.*` and don't drift.
 use crate::builtin::util::{to_integer, to_number as to_float};
-use crate::env::{Error, Function, LuaString, NativeContext, NativeFn, Stack, Table, Value};
+use crate::env::{
+    Error, Function, LuaString, MetamethodBits, NativeContext, NativeFn, Stack, Table, Userdata,
+    Value,
+};
+use crate::lua::{StashedError, StashedFunction, StashedTable, StashedValue};
+use crate::vm::async_sequence::{AsyncSequence, SequenceReturn, async_sequence};
+use crate::vm::interp::{IndexChain, walk_index_chain};
 use crate::vm::sequence::CallbackAction;
+
+mod pattern;
+use pattern::{CapValue, MatchState, PatError};
 
 /// Coerce a string-or-number argument to a `LuaString`, mirroring
 /// `luaL_checkstring` (numbers are accepted and stringified).
@@ -136,11 +147,101 @@ fn lua_dump<'gc>(
     todo!()
 }
 
+// ---------- pattern matching: shared helpers ----------
+
+/// Turn a `PatError` from the matcher into a Lua error at the call boundary.
+fn pat_err<'gc>(ctx: Context<'gc>, e: PatError) -> Error<'gc> {
+    Error::from_str(ctx, &e.message())
+}
+
+/// Build a `Value` from a resolved capture (substring or position).
+fn cap_to_value<'gc>(ctx: Context<'gc>, src: &[u8], cv: CapValue) -> Value<'gc> {
+    match cv {
+        CapValue::Str { start, end } => Value::string(LuaString::new(ctx, &src[start..end])),
+        CapValue::Pos(n) => Value::integer(n),
+    }
+}
+
+/// `posrelatI(pos, len) - 1`: the 0-based start index for `find`/`match`/
+/// `gmatch`. Returns `None` when the requested start is past the end of the
+/// string (`init > len`), which the callers treat as "no match" (or, for
+/// `gmatch`, "iterate nothing").
+fn init_pos(pos: i64, len: usize) -> Option<usize> {
+    // Mirrors `posrelatI`: positive is absolute, 0 -> 1, very negative clips to
+    // 1, otherwise counts from the end. The i128 compare avoids any overflow.
+    let one_based: usize = if pos > 0 {
+        pos as usize
+    } else if pos == 0 || (pos as i128) < -(len as i128) {
+        1 // 0 -> 1; anything more negative than -len clips to 1
+    } else {
+        (len as i64 + pos + 1) as usize // count from the end
+    };
+    let init = one_based - 1;
+    (init <= len).then_some(init)
+}
+
+/// `find(s, pattern [, init [, plain]])` — locate `pattern` in `s` from `init`
+/// (1-based, negatives from the end). Returns the 1-based start/end indices
+/// plus any captures, or nil. A `plain` flag — or a pattern with no magic
+/// characters — switches to a plain substring search.
 fn lua_find<'gc>(
-    _ctx: NativeContext<'gc, '_>,
-    _stack: Stack<'gc, '_>,
+    nctx: NativeContext<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
 ) -> Result<CallbackAction<'gc>, Error<'gc>> {
-    todo!()
+    let ctx = nctx.ctx;
+    let s = check_str(ctx, stack.get(0), "find", 1)?;
+    let p = check_str(ctx, stack.get(1), "find", 2)?;
+    let src = s.as_bytes();
+    let pat = p.as_bytes();
+
+    let init_arg = stack.get(2);
+    let init_raw = if init_arg.is_nil() {
+        1
+    } else {
+        util::check_integer(ctx, init_arg, "find", 3)?
+    };
+    let Some(init) = init_pos(init_raw, src.len()) else {
+        stack.replace(&[Value::nil()]);
+        return Ok(CallbackAction::Return);
+    };
+
+    // Plain search on explicit request or a pattern with no magic chars.
+    if !stack.get(3).is_falsy() || pattern::nospecials(pat) {
+        match pattern::plain_find(&src[init..], pat) {
+            Some(off) => {
+                let start = init + off;
+                stack.replace(&[
+                    Value::integer(start as i64 + 1),
+                    Value::integer((start + pat.len()) as i64),
+                ]);
+            }
+            None => stack.replace(&[Value::nil()]),
+        }
+        return Ok(CallbackAction::Return);
+    }
+
+    let anchor = pat.first() == Some(&b'^');
+    let body = if anchor { &pat[1..] } else { pat };
+    let mut ms = MatchState::new(src, body);
+    let mut s1 = init;
+    loop {
+        if let Some(e) = ms.match_at(s1).map_err(|e| pat_err(ctx, e))? {
+            // start, end, then the explicit captures (no whole-match fallback).
+            let mut out = vec![Value::integer(s1 as i64 + 1), Value::integer(e as i64)];
+            for i in 0..ms.num_captures(false) {
+                let cv = ms.get_onecapture(i, s1, e).map_err(|e| pat_err(ctx, e))?;
+                out.push(cap_to_value(ctx, src, cv));
+            }
+            stack.replace(&out);
+            return Ok(CallbackAction::Return);
+        }
+        if anchor || s1 >= src.len() {
+            break;
+        }
+        s1 += 1;
+    }
+    stack.replace(&[Value::nil()]);
+    Ok(CallbackAction::Return)
 }
 
 fn lua_format<'gc>(
@@ -889,18 +990,498 @@ fn apply_width(out: &mut Vec<u8>, spec: &FmtSpec, sign: &[u8], prefix: &[u8], bo
     }
 }
 
-fn lua_gmatch<'gc>(
-    _ctx: NativeContext<'gc, '_>,
-    _stack: Stack<'gc, '_>,
-) -> Result<CallbackAction<'gc>, Error<'gc>> {
-    todo!()
+/// Iterator state for `gmatch`, owned by the closure's userdata upvalue. The
+/// subject and pattern bytes are copied in so the closure needn't keep the
+/// argument strings rooted (mirroring PUC's `lua_settop` + userdata).
+struct GmatchState {
+    src: Vec<u8>,
+    pat: Vec<u8>,
+    /// Next subject byte to try matching from.
+    pos: usize,
+    /// End of the previous match — empty matches at this exact spot are
+    /// skipped so iteration always advances (PUC's `e != lastmatch`).
+    lastmatch: Option<usize>,
 }
 
-fn lua_gsub<'gc>(
-    _ctx: NativeContext<'gc, '_>,
-    _stack: Stack<'gc, '_>,
+/// `gmatch(s, pattern [, init])` — return an iterator that, on each call,
+/// yields the captures of the next match (whole match if no captures). Unlike
+/// `find`/`match`/`gsub`, a leading `^` is *not* an anchor here — it matches a
+/// literal `^` — because the iterator never strips it.
+fn lua_gmatch<'gc>(
+    nctx: NativeContext<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
 ) -> Result<CallbackAction<'gc>, Error<'gc>> {
-    todo!()
+    let ctx = nctx.ctx;
+    let s = check_str(ctx, stack.get(0), "gmatch", 1)?;
+    let p = check_str(ctx, stack.get(1), "gmatch", 2)?;
+    let init_arg = stack.get(2);
+    let init_raw = if init_arg.is_nil() {
+        1
+    } else {
+        util::check_integer(ctx, init_arg, "gmatch", 3)?
+    };
+    // `init > len` clamps to len+1 (iterate nothing) rather than erroring.
+    let pos = init_pos(init_raw, s.len()).unwrap_or(s.len() + 1);
+    let state = GmatchState {
+        src: s.as_bytes().to_vec(),
+        pat: p.as_bytes().to_vec(),
+        pos,
+        lastmatch: None,
+    };
+    let ud = Userdata::new(ctx.mutation(), RefCell::new(state), 0);
+    let iter = Function::new_native(ctx.mutation(), gmatch_aux, Box::new([Value::userdata(ud)]));
+    stack.replace(&[Value::function(iter)]);
+    Ok(CallbackAction::Return)
+}
+
+/// One step of a `gmatch` iterator: advance from the stored position to the
+/// next match and return its captures, or nothing when exhausted.
+fn gmatch_aux<'gc>(
+    nctx: NativeContext<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
+) -> Result<CallbackAction<'gc>, Error<'gc>> {
+    let ctx = nctx.ctx;
+    let ud = nctx.upvalues[0]
+        .get_userdata()
+        .expect("gmatch iterator upvalue must be a userdata");
+    let result = ud
+        .with_data::<RefCell<GmatchState>, _>(|cell| {
+            let mut st = cell.borrow_mut();
+            let st = &mut *st;
+            let mut ms = MatchState::new(&st.src, &st.pat);
+            let mut src_pos = st.pos;
+            loop {
+                if src_pos > st.src.len() {
+                    return Ok(None);
+                }
+                match ms.match_at(src_pos)? {
+                    Some(e) if Some(e) != st.lastmatch => {
+                        let n = ms.num_captures(true);
+                        let mut caps = Vec::with_capacity(n);
+                        for i in 0..n {
+                            let cv = ms.get_onecapture(i, src_pos, e)?;
+                            caps.push(cap_to_value(ctx, &st.src, cv));
+                        }
+                        // `ms` is unused past here, so its borrow of `st.src`/
+                        // `st.pat` ends and these field writes are allowed.
+                        st.pos = e;
+                        st.lastmatch = Some(e);
+                        return Ok(Some(caps));
+                    }
+                    _ => {}
+                }
+                src_pos += 1;
+            }
+        })
+        .expect("gmatch userdata payload type mismatch");
+    match result {
+        Err(e) => Err(pat_err(ctx, e)),
+        Ok(None) => {
+            stack.replace(&[]);
+            Ok(CallbackAction::Return)
+        }
+        Ok(Some(caps)) => {
+            stack.replace(&caps);
+            Ok(CallbackAction::Return)
+        }
+    }
+}
+
+/// `gsub(s, pattern, repl [, n])` — replace up to `n` (default: all)
+/// non-overlapping matches of `pattern` in `s`. `repl` may be a template
+/// string (`%0`–`%9`, `%%`), a number, a table (indexed by the first capture,
+/// honoring `__index`), or a function (called with the captures). Returns the
+/// result string and the substitution count.
+///
+/// A string/number `repl` resolves entirely in Rust (a synchronous return). A
+/// table/function `repl` re-enters the interpreter per match, so the work runs
+/// as an async `Sequence` (the same mechanism `table.sort` uses for its
+/// comparator).
+fn lua_gsub<'gc>(
+    nctx: NativeContext<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
+) -> Result<CallbackAction<'gc>, Error<'gc>> {
+    let ctx = nctx.ctx;
+    let s = check_str(ctx, stack.get(0), "gsub", 1)?;
+    let p = check_str(ctx, stack.get(1), "gsub", 2)?;
+    let repl = stack.get(2);
+    let n_arg = stack.get(3);
+    // Default cap is `len+1`: at most one match per position plus the empty
+    // match past the end, so this never truncates a real "replace all".
+    let max_n = if n_arg.is_nil() {
+        s.len() as i64 + 1
+    } else {
+        util::check_integer(ctx, n_arg, "gsub", 4)?
+    };
+
+    // Fast path: string/number replacement template, fully synchronous.
+    if let Some(template) = repl_template(ctx, repl) {
+        let (result, count) = gsub_string(ctx, s.as_bytes(), p.as_bytes(), &template, max_n)?;
+        stack.replace(&[result, Value::integer(count)]);
+        return Ok(CallbackAction::Return);
+    }
+
+    // Table/function replacement: re-enters the VM, so drive a sequence.
+    let repl_fn = repl.get_function();
+    let repl_tbl = repl.get_table();
+    if repl_fn.is_none() && repl_tbl.is_none() {
+        return Err(Error::from_str(
+            ctx,
+            &format!(
+                "bad argument #3 to 'gsub' (string/function/table expected, got {})",
+                repl.type_name()
+            ),
+        ));
+    }
+
+    let mc = ctx.mutation();
+    let src = s.as_bytes().to_vec();
+    let pat = p.as_bytes().to_vec();
+    let seq = async_sequence(mc, move |locals, seq| {
+        let repl = match (repl_fn, repl_tbl) {
+            (Some(f), _) => Repl::Func(locals.stash(mc, f)),
+            (_, Some(t)) => Repl::Table(locals.stash(mc, t)),
+            _ => unreachable!("repl kind validated above"),
+        };
+        async move {
+            let mut seq = seq;
+            let (result, count) = gsub_run(&mut seq, src, pat, repl, max_n).await?;
+            seq.enter(|_ctx, locals, _exec, mut stack| {
+                let result = locals.fetch(&result);
+                stack.replace(&[result, Value::integer(count)]);
+            });
+            Ok(SequenceReturn::Return)
+        }
+    });
+    Ok(CallbackAction::Sequence(seq))
+}
+
+/// The replacement template for a string/number `repl`, or `None` for other
+/// types. Numbers are stringified (as `lua_tolstring` would).
+fn repl_template<'gc>(ctx: Context<'gc>, v: Value<'gc>) -> Option<Vec<u8>> {
+    if let Some(s) = v.get_string() {
+        Some(s.as_bytes().to_vec())
+    } else if v.get_integer().is_some() || v.get_float().is_some() {
+        Some(util::basic_tostring(ctx, v).as_bytes().to_vec())
+    } else {
+        None
+    }
+}
+
+/// Synchronous `gsub` for a template `repl`. Returns the result string and the
+/// substitution count. The result is freshly interned; because identical bytes
+/// intern to the same `LuaString`, an all-misses run still yields the original
+/// string object (so PUC's "return the original on no change" identity holds).
+fn gsub_string<'gc>(
+    ctx: Context<'gc>,
+    src: &[u8],
+    pat: &[u8],
+    template: &[u8],
+    max_n: i64,
+) -> Result<(Value<'gc>, i64), Error<'gc>> {
+    let anchor = pat.first() == Some(&b'^');
+    let body = if anchor { &pat[1..] } else { pat };
+    let mut ms = MatchState::new(src, body);
+    let mut out: Vec<u8> = Vec::new();
+    let mut pos = 0usize;
+    let mut lastmatch: Option<usize> = None;
+    let mut count: i64 = 0;
+    while count < max_n {
+        let m = ms.match_at(pos).map_err(|e| pat_err(ctx, e))?;
+        match m {
+            Some(e) if Some(e) != lastmatch => {
+                count += 1;
+                add_s(ctx, &mut out, &ms, src, pos, e, template)?;
+                pos = e;
+                lastmatch = Some(e);
+            }
+            _ => {
+                if pos < src.len() {
+                    out.push(src[pos]);
+                    pos += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        if anchor {
+            break;
+        }
+    }
+    out.extend_from_slice(&src[pos..]);
+    Ok((Value::string(LuaString::new(ctx, &out)), count))
+}
+
+/// Expand a replacement template (`add_s`) for the match `src[s..e]` into
+/// `out`: `%0` is the whole match, `%1`–`%9` the captures, `%%` a literal `%`;
+/// any other `%x` is an error.
+fn add_s<'gc>(
+    ctx: Context<'gc>,
+    out: &mut Vec<u8>,
+    ms: &MatchState,
+    src: &[u8],
+    s: usize,
+    e: usize,
+    template: &[u8],
+) -> Result<(), Error<'gc>> {
+    let invalid = || Error::from_str(ctx, "invalid use of '%' in replacement string");
+    let mut i = 0;
+    while i < template.len() {
+        let b = template[i];
+        if b != b'%' {
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        i += 1;
+        let c = *template.get(i).ok_or_else(invalid)?;
+        i += 1;
+        if c == b'%' {
+            out.push(b'%');
+        } else if c == b'0' {
+            out.extend_from_slice(&src[s..e]);
+        } else if c.is_ascii_digit() {
+            match ms
+                .get_onecapture((c - b'1') as usize, s, e)
+                .map_err(|er| pat_err(ctx, er))?
+            {
+                CapValue::Str { start, end } => out.extend_from_slice(&src[start..end]),
+                CapValue::Pos(n) => util::push_int(out, n),
+            }
+        } else {
+            return Err(invalid());
+        }
+    }
+    Ok(())
+}
+
+/// Stashed table/function replacement target for the sequence path.
+enum Repl {
+    Func(StashedFunction),
+    Table(StashedTable),
+}
+
+/// A capture extracted into owned bytes (or a position) so it can outlive the
+/// transient `MatchState` borrow across an `.await`.
+enum OwnedCap {
+    Bytes(Vec<u8>),
+    Pos(i64),
+}
+
+impl OwnedCap {
+    fn to_value<'gc>(&self, ctx: Context<'gc>) -> Value<'gc> {
+        match self {
+            OwnedCap::Bytes(b) => Value::string(LuaString::new(ctx, b)),
+            OwnedCap::Pos(n) => Value::integer(*n),
+        }
+    }
+}
+
+/// What a single match's replacement resolves to.
+enum ReplResult {
+    /// Keep the original matched text (function/table returned nil/false).
+    Keep,
+    /// Substitute these bytes.
+    Bytes(Vec<u8>),
+}
+
+/// One iteration's matching decision, extracted synchronously so the borrow of
+/// the subject/pattern by `MatchState` never spans an `.await`.
+enum GsubStep {
+    /// A match ending at `e`; `whole` is the matched text and `caps` the
+    /// replacement arguments (all captures for a function, just the first for
+    /// a table).
+    Replace {
+        whole: Vec<u8>,
+        caps: Vec<OwnedCap>,
+        e: usize,
+    },
+    /// No match here: copy one subject byte and advance.
+    SkipChar,
+    /// End of subject: stop.
+    End,
+}
+
+/// Async `gsub` for a table/function `repl`. Mirrors `gsub_string`'s loop but
+/// resolves each replacement by re-entering the VM (`seq.call` for a function,
+/// a `__index`-honoring index for a table).
+async fn gsub_run(
+    seq: &mut AsyncSequence,
+    src: Vec<u8>,
+    pat: Vec<u8>,
+    repl: Repl,
+    max_n: i64,
+) -> Result<(StashedValue, i64), StashedError> {
+    let anchor = pat.first() == Some(&b'^');
+    let pat_off = if anchor { 1 } else { 0 };
+    let is_func = matches!(repl, Repl::Func(_));
+
+    let mut out: Vec<u8> = Vec::new();
+    let mut pos = 0usize;
+    let mut lastmatch: Option<usize> = None;
+    let mut count: i64 = 0;
+
+    while count < max_n {
+        // Synchronous matching block — `MatchState` lives and dies here, so its
+        // borrow of `src`/`pat` never crosses the awaits below.
+        let step: Result<GsubStep, PatError> = (|| {
+            let mut ms = MatchState::new(&src, &pat[pat_off..]);
+            match ms.match_at(pos)? {
+                Some(e) if Some(e) != lastmatch => {
+                    // Function: all captures as call args. Table: just the
+                    // first capture (whole match if there are no captures).
+                    let n = if is_func { ms.num_captures(true) } else { 1 };
+                    let mut caps = Vec::with_capacity(n);
+                    for i in 0..n {
+                        caps.push(match ms.get_onecapture(i, pos, e)? {
+                            CapValue::Str { start, end } => {
+                                OwnedCap::Bytes(src[start..end].to_vec())
+                            }
+                            CapValue::Pos(p) => OwnedCap::Pos(p),
+                        });
+                    }
+                    Ok(GsubStep::Replace {
+                        whole: src[pos..e].to_vec(),
+                        caps,
+                        e,
+                    })
+                }
+                _ => Ok(if pos < src.len() {
+                    GsubStep::SkipChar
+                } else {
+                    GsubStep::End
+                }),
+            }
+        })();
+
+        match step.map_err(|e| stash_pat_err(seq, e))? {
+            GsubStep::Replace { whole, caps, e } => {
+                count += 1;
+                let res = match &repl {
+                    Repl::Func(f) => call_func_repl(seq, f, &caps).await?,
+                    Repl::Table(t) => table_index_repl(seq, t, &caps[0]).await?,
+                };
+                match res {
+                    ReplResult::Keep => out.extend_from_slice(&whole),
+                    ReplResult::Bytes(b) => out.extend_from_slice(&b),
+                }
+                pos = e;
+                lastmatch = Some(e);
+            }
+            GsubStep::SkipChar => {
+                out.push(src[pos]);
+                pos += 1;
+            }
+            GsubStep::End => break,
+        }
+        if anchor {
+            break;
+        }
+    }
+    out.extend_from_slice(&src[pos..]);
+
+    let result = seq.enter(|ctx, locals, _exec, _stack| {
+        locals.stash(ctx.mutation(), Value::string(LuaString::new(ctx, &out)))
+    });
+    Ok((result, count))
+}
+
+/// Call a function `repl` with the captures as arguments and classify its
+/// first result.
+async fn call_func_repl(
+    seq: &mut AsyncSequence,
+    f: &StashedFunction,
+    caps: &[OwnedCap],
+) -> Result<ReplResult, StashedError> {
+    seq.enter(|ctx, _locals, _exec, mut stack| {
+        stack.clear();
+        for c in caps {
+            stack.push(c.to_value(ctx));
+        }
+    });
+    seq.call(f, 0).await?;
+    seq.try_enter(|ctx, _locals, _exec, stack| classify_repl_result(ctx, stack.get(0)))
+}
+
+/// Index a table `repl` by `key` (honoring `__index`, which may itself be a
+/// function requiring a call) and classify the result.
+async fn table_index_repl(
+    seq: &mut AsyncSequence,
+    t: &StashedTable,
+    key: &OwnedCap,
+) -> Result<ReplResult, StashedError> {
+    enum Plan {
+        Resolved(ReplResult),
+        CallIndex(StashedFunction),
+    }
+    let plan = seq.try_enter(|ctx, locals, _exec, mut stack| {
+        let tbl = locals.fetch(t);
+        let key_val = key.to_value(ctx);
+        let v = tbl.raw_get(key_val);
+        if !v.is_nil() {
+            return Ok(Plan::Resolved(classify_repl_result(ctx, v)?));
+        }
+        if !tbl.shape().has_mm(MetamethodBits::INDEX) {
+            return Ok(Plan::Resolved(ReplResult::Keep)); // nil -> keep original
+        }
+        // INDEX bit implies a metatable is present.
+        let mt = tbl
+            .metatable()
+            .expect("INDEX metamethod implies a metatable");
+        match walk_index_chain(Value::table(tbl), mt, key_val, ctx.symbols().mm_index) {
+            IndexChain::Resolved(rv) => Ok(Plan::Resolved(classify_repl_result(ctx, rv)?)),
+            IndexChain::Invoke { func, receiver } => match func.get_function() {
+                Some(f) => {
+                    stack.replace(&[receiver, key_val]);
+                    Ok(Plan::CallIndex(locals.stash(ctx.mutation(), f)))
+                }
+                // A non-function, non-table `__index` (e.g. a callable userdata
+                // with its own `__call`) is too exotic to drive here; calling a
+                // plain non-function would raise anyway.
+                None => Err(Error::from_str(
+                    ctx,
+                    &format!("attempt to call a {} value", func.type_name()),
+                )),
+            },
+            IndexChain::Exhausted => Err(Error::from_str(
+                ctx,
+                "'__index' chain too long; possible loop",
+            )),
+        }
+    })?;
+    match plan {
+        Plan::Resolved(r) => Ok(r),
+        Plan::CallIndex(f) => {
+            seq.call(&f, 0).await?;
+            seq.try_enter(|ctx, _locals, _exec, stack| classify_repl_result(ctx, stack.get(0)))
+        }
+    }
+}
+
+/// Classify a function/table replacement result: nil/false keeps the original;
+/// a string or number substitutes; anything else is an error (matching PUC's
+/// `lua_isstring` test, which accepts numbers).
+fn classify_repl_result<'gc>(ctx: Context<'gc>, v: Value<'gc>) -> Result<ReplResult, Error<'gc>> {
+    if v.is_falsy() {
+        Ok(ReplResult::Keep)
+    } else if let Some(s) = v.get_string() {
+        Ok(ReplResult::Bytes(s.as_bytes().to_vec()))
+    } else if v.get_integer().is_some() || v.get_float().is_some() {
+        Ok(ReplResult::Bytes(
+            util::basic_tostring(ctx, v).as_bytes().to_vec(),
+        ))
+    } else {
+        Err(Error::from_str(
+            ctx,
+            &format!("invalid replacement value (a {})", v.type_name()),
+        ))
+    }
+}
+
+/// Convert a matcher `PatError` into a `StashedError` from inside a sequence.
+fn stash_pat_err(seq: &mut AsyncSequence, e: PatError) -> StashedError {
+    seq.try_enter(|ctx, _locals, _exec, _stack| Result::<(), _>::Err(pat_err(ctx, e)))
+        .unwrap_err()
 }
 
 /// `len(s)` — number of bytes in `s`.
@@ -924,11 +1505,52 @@ fn lua_lower<'gc>(
     Ok(CallbackAction::Return)
 }
 
+/// `match(s, pattern [, init])` — return the captures of the first match of
+/// `pattern` in `s` from `init`, or the whole match if the pattern has no
+/// captures; nil if there is no match.
 fn lua_match<'gc>(
-    _ctx: NativeContext<'gc, '_>,
-    _stack: Stack<'gc, '_>,
+    nctx: NativeContext<'gc, '_>,
+    mut stack: Stack<'gc, '_>,
 ) -> Result<CallbackAction<'gc>, Error<'gc>> {
-    todo!()
+    let ctx = nctx.ctx;
+    let s = check_str(ctx, stack.get(0), "match", 1)?;
+    let p = check_str(ctx, stack.get(1), "match", 2)?;
+    let src = s.as_bytes();
+    let pat = p.as_bytes();
+
+    let init_arg = stack.get(2);
+    let init_raw = if init_arg.is_nil() {
+        1
+    } else {
+        util::check_integer(ctx, init_arg, "match", 3)?
+    };
+    let Some(init) = init_pos(init_raw, src.len()) else {
+        stack.replace(&[Value::nil()]);
+        return Ok(CallbackAction::Return);
+    };
+
+    let anchor = pat.first() == Some(&b'^');
+    let body = if anchor { &pat[1..] } else { pat };
+    let mut ms = MatchState::new(src, body);
+    let mut s1 = init;
+    loop {
+        if let Some(e) = ms.match_at(s1).map_err(|e| pat_err(ctx, e))? {
+            let n = ms.num_captures(true); // whole match if no captures
+            let mut out = Vec::with_capacity(n);
+            for i in 0..n {
+                let cv = ms.get_onecapture(i, s1, e).map_err(|e| pat_err(ctx, e))?;
+                out.push(cap_to_value(ctx, src, cv));
+            }
+            stack.replace(&out);
+            return Ok(CallbackAction::Return);
+        }
+        if anchor || s1 >= src.len() {
+            break;
+        }
+        s1 += 1;
+    }
+    stack.replace(&[Value::nil()]);
+    Ok(CallbackAction::Return)
 }
 
 fn lua_pack<'gc>(

--- a/src/builtin/string/pattern.rs
+++ b/src/builtin/string/pattern.rs
@@ -1,0 +1,698 @@
+//! Lua pattern-matching engine — a faithful port of the matcher in PUC-Lua
+//! 5.5's `lstrlib.c` (`match`, `classend`, `singlematch`, `max_expand`, …).
+//!
+//! This module is deliberately free of any GC / `Context` dependency: it
+//! operates purely on byte slices and reports matches as index ranges, so it
+//! is exhaustively unit-testable on its own. The `string.{find,match,gmatch,
+//! gsub}` callbacks in the parent module wrap it, turning captures into
+//! `Value`s and (for `gsub`) driving native→Lua re-entry.
+//!
+//! Semantics mirror the reference exactly, including the C-locale `ctype`
+//! classification (ASCII only — bytes ≥ 0x80 are unclassified) and the
+//! `'^' $ * + ? . ( [ % -` set of magic characters. Pattern positions and
+//! subject positions are byte indices; anchoring (`^`) is handled by the
+//! caller (`find`/`match`/`gsub` strip it; `gmatch` does not, so there `^`
+//! is a literal), matching `str_find_aux` / `gmatch`.
+
+/// `LUA_MAXCAPTURES` — the capture array is fixed-size in the reference.
+pub const MAX_CAPTURES: usize = 32;
+
+/// `MAXCCALLS` — recursion-depth guard for `match` (raises "pattern too
+/// complex" rather than overflowing the native stack).
+const MAX_CCALLS: i32 = 200;
+
+const L_ESC: u8 = b'%';
+/// `SPECIALS` from `lstrlib.c`; a pattern with none of these is a plain
+/// substring (`nospecials`).
+const SPECIALS: &[u8] = b"^$*+?.([%-";
+
+/// Length/kind of a capture, mirroring the `CAP_*` sentinels.
+#[derive(Clone, Copy)]
+enum CapLen {
+    /// Capture opened (`(`) but not yet closed (`CAP_UNFINISHED`).
+    Unfinished,
+    /// Position capture `()` (`CAP_POSITION`).
+    Position,
+    /// Closed string capture of this byte length.
+    Len(usize),
+}
+
+#[derive(Clone, Copy)]
+struct Capture {
+    /// Byte offset into the subject where this capture begins.
+    init: usize,
+    len: CapLen,
+}
+
+/// A resolved capture, ready to become a `Value`.
+pub enum CapValue {
+    /// A substring of the subject (`subject[start..end]`).
+    Str { start: usize, end: usize },
+    /// A position capture: a 1-based byte position.
+    Pos(i64),
+}
+
+/// A malformed-pattern / capture error. Carries enough to reproduce the
+/// reference's exact message (raised as a Lua error at the call boundary).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PatError {
+    EndsWithPercent,
+    MissingBracket,
+    BalanceArgs,
+    MissingFrontierBracket,
+    /// `invalid capture index %N` — `N` may be 0 (from `%0` as a back-reference).
+    InvalidCaptureIndex(i32),
+    InvalidPatternCapture,
+    UnfinishedCapture,
+    TooManyCaptures,
+    PatternTooComplex,
+}
+
+impl PatError {
+    pub fn message(self) -> String {
+        match self {
+            PatError::EndsWithPercent => "malformed pattern (ends with '%')".into(),
+            PatError::MissingBracket => "malformed pattern (missing ']')".into(),
+            PatError::BalanceArgs => "malformed pattern (missing arguments to '%b')".into(),
+            PatError::MissingFrontierBracket => "missing '[' after '%f' in pattern".into(),
+            PatError::InvalidCaptureIndex(n) => format!("invalid capture index %{n}"),
+            PatError::InvalidPatternCapture => "invalid pattern capture".into(),
+            PatError::UnfinishedCapture => "unfinished capture".into(),
+            PatError::TooManyCaptures => "too many captures".into(),
+            PatError::PatternTooComplex => "pattern too complex".into(),
+        }
+    }
+}
+
+type PatResult<T> = Result<T, PatError>;
+
+/// One step of `match`'s manual tail-call loop (the `goto init` vs fall-through
+/// distinction in the reference). `Init` re-enters the loop with new `(s, p)`;
+/// `Done` returns the match result.
+enum Step {
+    Init(usize, usize),
+    Done(Option<usize>),
+}
+
+// ---------------------------------------------------------------------------
+// C-locale ctype helpers (ASCII only; bytes >= 0x80 classify as nothing).
+// ---------------------------------------------------------------------------
+
+/// `isspace`: space, `\t \n \v \f \r`. NB: includes `\v` (0x0B), which Rust's
+/// `u8::is_ascii_whitespace` omits — so it must be spelled out here.
+#[inline]
+fn is_space(c: u8) -> bool {
+    c == b' ' || (0x09..=0x0D).contains(&c)
+}
+
+/// `match_class`: does byte `c` match the single class letter `cl`?
+/// A lowercase letter is the class; its uppercase form is the complement.
+/// A non-letter `cl` matches itself literally (e.g. `%.` → '.').
+fn match_class(c: u8, cl: u8) -> bool {
+    let res = match cl.to_ascii_lowercase() {
+        b'a' => c.is_ascii_alphabetic(),
+        b'c' => c.is_ascii_control(),
+        b'd' => c.is_ascii_digit(),
+        b'g' => c.is_ascii_graphic(),
+        b'l' => c.is_ascii_lowercase(),
+        b'p' => c.is_ascii_punctuation(),
+        b's' => is_space(c),
+        b'u' => c.is_ascii_uppercase(),
+        b'w' => c.is_ascii_alphanumeric(),
+        b'x' => c.is_ascii_hexdigit(),
+        b'z' => c == 0, // deprecated, but still honored by the reference
+        _ => return cl == c,
+    };
+    if cl.is_ascii_lowercase() { res } else { !res }
+}
+
+/// `matchbracketclass`: does `c` match the set `pat[p_brk..=ec]` (`p_brk` is
+/// the `[`, `ec` is the closing `]`)? Handles `^` negation, `%x` class escapes,
+/// and `a-z` ranges, exactly as the reference's pointer walk.
+fn match_bracket_class(c: u8, pat: &[u8], p_brk: usize, ec: usize) -> bool {
+    let mut sig = true;
+    let mut p = p_brk; // at '['
+    if pat.get(p + 1) == Some(&b'^') {
+        sig = false;
+        p += 1; // skip the '^'
+    }
+    loop {
+        p += 1; // C's `while (++p < ec)`
+        if p >= ec {
+            break;
+        }
+        if pat[p] == L_ESC {
+            p += 1;
+            if p < pat.len() && match_class(c, pat[p]) {
+                return sig;
+            }
+        } else if pat.get(p + 1) == Some(&b'-') && p + 2 < ec {
+            // A range `lo-hi`; the closing-adjacent `-` (p+2 == ec) is literal.
+            let lo = pat[p];
+            let hi = pat[p + 2];
+            p += 2;
+            if lo <= c && c <= hi {
+                return sig;
+            }
+        } else if pat[p] == c {
+            return sig;
+        }
+    }
+    !sig
+}
+
+/// True iff the pattern contains no magic character (`nospecials`): the caller
+/// can then use a plain substring search. NUL bytes in the pattern are fine —
+/// unlike the reference's `strpbrk` scan we just look at every byte.
+pub fn nospecials(pat: &[u8]) -> bool {
+    !pat.iter().any(|b| SPECIALS.contains(b))
+}
+
+/// Plain substring search (`lmemfind` / `memchr` loop): byte offset of the
+/// first occurrence of `needle` in `hay`, or `None`. Empty needle matches at 0.
+pub fn plain_find(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > hay.len() {
+        return None;
+    }
+    let first = needle[0];
+    let last_start = hay.len() - needle.len();
+    let mut i = 0;
+    while i <= last_start {
+        if hay[i] == first && hay[i..i + needle.len()] == *needle {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The pattern matcher state. Borrows the subject and pattern; the pattern
+/// passed in has already had any leading `^` stripped by the caller (where
+/// anchoring applies).
+pub struct MatchState<'a> {
+    src: &'a [u8],
+    pat: &'a [u8],
+    level: usize,
+    matchdepth: i32,
+    capture: [Capture; MAX_CAPTURES],
+}
+
+impl<'a> MatchState<'a> {
+    pub fn new(src: &'a [u8], pat: &'a [u8]) -> Self {
+        MatchState {
+            src,
+            pat,
+            level: 0,
+            matchdepth: MAX_CCALLS,
+            capture: [Capture {
+                init: 0,
+                len: CapLen::Unfinished,
+            }; MAX_CAPTURES],
+        }
+    }
+
+    /// Attempt a match anchored at subject byte `s` (`reprepstate` + `match`).
+    /// Returns the byte index one past the match end, or `None` if no match
+    /// starts here.
+    pub fn match_at(&mut self, s: usize) -> PatResult<Option<usize>> {
+        self.level = 0;
+        self.matchdepth = MAX_CCALLS;
+        self.do_match(s, 0)
+    }
+
+    /// Number of captures `push_captures` would yield (`has_whole` is true when
+    /// the whole match should stand in for the zero-capture case, as in
+    /// `match`/`gmatch` but not `find`).
+    pub fn num_captures(&self, has_whole: bool) -> usize {
+        if self.level == 0 && has_whole {
+            1
+        } else {
+            self.level
+        }
+    }
+
+    /// Resolve the `i`-th capture against the whole-match range `[ws, we)`
+    /// (`get_onecapture`). Index `0` with no captures yields the whole match.
+    pub fn get_onecapture(&self, i: usize, ws: usize, we: usize) -> PatResult<CapValue> {
+        if i >= self.level {
+            if i != 0 {
+                return Err(PatError::InvalidCaptureIndex(i as i32 + 1));
+            }
+            Ok(CapValue::Str { start: ws, end: we })
+        } else {
+            match self.capture[i].len {
+                CapLen::Unfinished => Err(PatError::UnfinishedCapture),
+                CapLen::Position => Ok(CapValue::Pos(self.capture[i].init as i64 + 1)),
+                CapLen::Len(n) => Ok(CapValue::Str {
+                    start: self.capture[i].init,
+                    end: self.capture[i].init + n,
+                }),
+            }
+        }
+    }
+
+    /// `classend`: index just past the pattern item starting at `p` (a single
+    /// char, a `%x` escape, or a `[set]`).
+    fn classend(&self, p: usize) -> PatResult<usize> {
+        let c = self.pat[p];
+        let mut p = p + 1;
+        match c {
+            L_ESC => {
+                if p >= self.pat.len() {
+                    return Err(PatError::EndsWithPercent);
+                }
+                Ok(p + 1)
+            }
+            b'[' => {
+                if self.pat.get(p) == Some(&b'^') {
+                    p += 1;
+                }
+                // do { ... } while (*p != ']')
+                loop {
+                    if p >= self.pat.len() {
+                        return Err(PatError::MissingBracket);
+                    }
+                    let ch = self.pat[p];
+                    p += 1;
+                    if ch == L_ESC && p < self.pat.len() {
+                        p += 1; // skip an escaped char (e.g. '%]')
+                    }
+                    if self.pat.get(p) == Some(&b']') {
+                        break;
+                    }
+                }
+                Ok(p + 1)
+            }
+            _ => Ok(p),
+        }
+    }
+
+    /// `singlematch`: does `src[s]` match the single pattern item at `p`
+    /// (whose end is `ep`)?
+    fn single_match(&self, s: usize, p: usize, ep: usize) -> bool {
+        if s >= self.src.len() {
+            return false;
+        }
+        let c = self.src[s];
+        match self.pat[p] {
+            b'.' => true,
+            L_ESC => match_class(c, self.pat[p + 1]),
+            b'[' => match_bracket_class(c, self.pat, p, ep - 1),
+            other => other == c,
+        }
+    }
+
+    /// `matchbalance` (`%b`): match a balanced run delimited by `pat[p]` /
+    /// `pat[p+1]` starting at `src[s]`.
+    fn match_balance(&self, s: usize, p: usize) -> PatResult<Option<usize>> {
+        if p + 1 >= self.pat.len() {
+            return Err(PatError::BalanceArgs);
+        }
+        let b = self.pat[p];
+        let e = self.pat[p + 1];
+        if s >= self.src.len() || self.src[s] != b {
+            return Ok(None);
+        }
+        let mut cont = 1i32;
+        let mut s = s + 1;
+        while s < self.src.len() {
+            if self.src[s] == e {
+                cont -= 1;
+                if cont == 0 {
+                    return Ok(Some(s + 1));
+                }
+            } else if self.src[s] == b {
+                cont += 1;
+            }
+            s += 1;
+        }
+        Ok(None) // string ends out of balance
+    }
+
+    /// `max_expand`: greedy `*`/`+` — match as many as possible, then back off.
+    fn max_expand(&mut self, s: usize, p: usize, ep: usize) -> PatResult<Option<usize>> {
+        let mut i = 0;
+        while self.single_match(s + i, p, ep) {
+            i += 1;
+        }
+        loop {
+            if let Some(res) = self.do_match(s + i, ep + 1)? {
+                return Ok(Some(res));
+            }
+            if i == 0 {
+                return Ok(None);
+            }
+            i -= 1;
+        }
+    }
+
+    /// `min_expand`: lazy `-` — match as few as possible, growing on failure.
+    fn min_expand(&mut self, mut s: usize, p: usize, ep: usize) -> PatResult<Option<usize>> {
+        loop {
+            if let Some(res) = self.do_match(s, ep + 1)? {
+                return Ok(Some(res));
+            }
+            if self.single_match(s, p, ep) {
+                s += 1;
+            } else {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn capture_to_close(&self) -> PatResult<usize> {
+        for level in (0..self.level).rev() {
+            if matches!(self.capture[level].len, CapLen::Unfinished) {
+                return Ok(level);
+            }
+        }
+        Err(PatError::InvalidPatternCapture)
+    }
+
+    fn start_capture(&mut self, s: usize, p: usize, what: CapLen) -> PatResult<Option<usize>> {
+        let level = self.level;
+        if level >= MAX_CAPTURES {
+            return Err(PatError::TooManyCaptures);
+        }
+        self.capture[level] = Capture { init: s, len: what };
+        self.level = level + 1;
+        let res = self.do_match(s, p)?;
+        if res.is_none() {
+            self.level -= 1; // undo capture
+        }
+        Ok(res)
+    }
+
+    fn end_capture(&mut self, s: usize, p: usize) -> PatResult<Option<usize>> {
+        let l = self.capture_to_close()?;
+        self.capture[l].len = CapLen::Len(s - self.capture[l].init);
+        let res = self.do_match(s, p)?;
+        if res.is_none() {
+            self.capture[l].len = CapLen::Unfinished; // undo
+        }
+        Ok(res)
+    }
+
+    /// `check_capture`: resolve a back-reference digit to a closed capture index.
+    fn check_capture(&self, digit: u8) -> PatResult<usize> {
+        let l = digit as i32 - b'1' as i32;
+        if l < 0
+            || l as usize >= self.level
+            || matches!(self.capture[l as usize].len, CapLen::Unfinished)
+        {
+            return Err(PatError::InvalidCaptureIndex(l + 1));
+        }
+        Ok(l as usize)
+    }
+
+    /// `match_capture` (`%1`–`%9`): match the literal text of capture `digit`.
+    fn match_capture(&mut self, s: usize, digit: u8) -> PatResult<Option<usize>> {
+        let l = self.check_capture(digit)?;
+        let len = match self.capture[l].len {
+            CapLen::Len(n) => n,
+            // check_capture rejects unfinished/position captures via the index
+            // check; a closed string capture is the only remaining kind.
+            _ => return Ok(None),
+        };
+        let init = self.capture[l].init;
+        if self.src.len() - s >= len && self.src[init..init + len] == self.src[s..s + len] {
+            Ok(Some(s + len))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// The `dflt:` block of `match`: a pattern item plus an optional suffix
+    /// (`* + ? -`). Returns whether to loop (`Init`) or finish (`Done`).
+    fn match_default(&mut self, s: usize, p: usize) -> PatResult<Step> {
+        let ep = self.classend(p)?;
+        if !self.single_match(s, p, ep) {
+            match self.pat.get(ep) {
+                // `*` `?` `-` accept zero repetitions: skip the item.
+                Some(b'*') | Some(b'?') | Some(b'-') => Ok(Step::Init(s, ep + 1)),
+                // `+` or no suffix: failure.
+                _ => Ok(Step::Done(None)),
+            }
+        } else {
+            match self.pat.get(ep) {
+                Some(b'?') => {
+                    if let Some(res) = self.do_match(s + 1, ep + 1)? {
+                        Ok(Step::Done(Some(res)))
+                    } else {
+                        Ok(Step::Init(s, ep + 1))
+                    }
+                }
+                Some(b'+') => Ok(Step::Done(self.max_expand(s + 1, p, ep)?)),
+                Some(b'*') => Ok(Step::Done(self.max_expand(s, p, ep)?)),
+                Some(b'-') => Ok(Step::Done(self.min_expand(s, p, ep)?)),
+                _ => Ok(Step::Init(s + 1, ep)), // no suffix
+            }
+        }
+    }
+
+    /// `match`: the core recursive matcher. The `init:` tail-call loop is a
+    /// `loop` with `Step::Init` re-entry; genuinely recursive cases (`?`,
+    /// `*`/`+`/`-` expansion, captures) call `do_match` directly.
+    fn do_match(&mut self, mut s: usize, mut p: usize) -> PatResult<Option<usize>> {
+        if self.matchdepth == 0 {
+            return Err(PatError::PatternTooComplex);
+        }
+        self.matchdepth -= 1;
+        let res = loop {
+            if p >= self.pat.len() {
+                break Some(s); // end of pattern
+            }
+            let step = match self.pat[p] {
+                b'(' => {
+                    if self.pat.get(p + 1) == Some(&b')') {
+                        Step::Done(self.start_capture(s, p + 2, CapLen::Position)?)
+                    } else {
+                        Step::Done(self.start_capture(s, p + 1, CapLen::Unfinished)?)
+                    }
+                }
+                b')' => Step::Done(self.end_capture(s, p + 1)?),
+                b'$' if p + 1 == self.pat.len() => Step::Done((s == self.src.len()).then_some(s)),
+                L_ESC => match self.pat.get(p + 1).copied() {
+                    Some(b'b') => match self.match_balance(s, p + 2)? {
+                        Some(ns) => Step::Init(ns, p + 4),
+                        None => Step::Done(None),
+                    },
+                    Some(b'f') => {
+                        let fp = p + 2;
+                        if self.pat.get(fp) != Some(&b'[') {
+                            self.matchdepth += 1;
+                            return Err(PatError::MissingFrontierBracket);
+                        }
+                        let ep = self.classend(fp)?;
+                        let prev = if s == 0 { 0 } else { self.src[s - 1] };
+                        let cur = if s < self.src.len() { self.src[s] } else { 0 };
+                        if !match_bracket_class(prev, self.pat, fp, ep - 1)
+                            && match_bracket_class(cur, self.pat, fp, ep - 1)
+                        {
+                            Step::Init(s, ep)
+                        } else {
+                            Step::Done(None)
+                        }
+                    }
+                    Some(d @ b'0'..=b'9') => match self.match_capture(s, d)? {
+                        Some(ns) => Step::Init(ns, p + 2),
+                        None => Step::Done(None),
+                    },
+                    // `%` + non-class / EOF: a literal escape — fall to default.
+                    _ => self.match_default(s, p)?,
+                },
+                _ => self.match_default(s, p)?,
+            };
+            match step {
+                Step::Init(ns, np) => {
+                    s = ns;
+                    p = np;
+                }
+                Step::Done(r) => break r,
+            }
+        };
+        self.matchdepth += 1;
+        Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run a full anchored-from-each-position scan like `string.match` would,
+    /// returning the (start, end) of the first match (byte indices).
+    fn first_match(src: &[u8], pat: &[u8]) -> Option<(usize, usize)> {
+        let anchor = pat.first() == Some(&b'^');
+        let pat = if anchor { &pat[1..] } else { pat };
+        let mut ms = MatchState::new(src, pat);
+        let mut s = 0;
+        loop {
+            if let Some(e) = ms.match_at(s).unwrap() {
+                return Some((s, e));
+            }
+            if anchor || s >= src.len() {
+                return None;
+            }
+            s += 1;
+        }
+    }
+
+    fn whole(src: &str, pat: &str) -> Option<String> {
+        first_match(src.as_bytes(), pat.as_bytes())
+            .map(|(s, e)| String::from_utf8_lossy(&src.as_bytes()[s..e]).into_owned())
+    }
+
+    #[test]
+    fn literals_and_dot() {
+        assert_eq!(first_match(b"hello", b"ell"), Some((1, 4)));
+        assert_eq!(first_match(b"hello", b"xyz"), None);
+        assert_eq!(first_match(b"abc", b"a.c"), Some((0, 3)));
+    }
+
+    #[test]
+    fn anchors() {
+        assert_eq!(first_match(b"abc", b"^a"), Some((0, 1)));
+        assert_eq!(first_match(b"abc", b"^b"), None);
+        assert_eq!(first_match(b"abc", b"c$"), Some((2, 3)));
+        assert_eq!(first_match(b"abc", b"b$"), None);
+        assert_eq!(first_match(b"", b"^$"), Some((0, 0)));
+    }
+
+    #[test]
+    fn quantifiers() {
+        assert_eq!(whole("aaa", "a*"), Some("aaa".into()));
+        assert_eq!(whole("baaa", "a*"), Some("".into())); // greedy-but-empty at pos 0
+        assert_eq!(whole("aaab", "a+"), Some("aaa".into()));
+        assert_eq!(whole("aaab", "a-b"), Some("aaab".into())); // lazy then 'b'
+        assert_eq!(whole("color", "colou?r"), Some("color".into()));
+        assert_eq!(whole("colour", "colou?r"), Some("colour".into()));
+    }
+
+    #[test]
+    fn classes() {
+        assert_eq!(whole("  abc", "%a+"), Some("abc".into()));
+        assert_eq!(whole("abc123", "%d+"), Some("123".into()));
+        assert_eq!(whole("abc123", "%D+"), Some("abc".into()));
+        assert_eq!(whole("a b\tc", "%s"), Some(" ".into()));
+        // \v is whitespace in the C locale (and here), unlike Rust's default.
+        assert_eq!(whole("x\x0by", "%s"), Some("\x0b".into()));
+    }
+
+    #[test]
+    fn sets() {
+        assert_eq!(whole("hello", "[el]+"), Some("ell".into()));
+        assert_eq!(whole("hello", "[^el]+"), Some("h".into()));
+        assert_eq!(whole("a-b]c", "[]%-]"), Some("-".into())); // ']' literal first, '-' escaped
+        assert_eq!(whole("Z", "[A-Z]"), Some("Z".into()));
+        assert_eq!(whole("5", "[0-9a-f]"), Some("5".into()));
+    }
+
+    #[test]
+    fn captures_and_positions() {
+        let src = b"hello world";
+        let pat = b"(%w+)%s+(%w+)";
+        let (s, e) = first_match(src, pat).unwrap();
+        let mut ms = MatchState::new(src, pat);
+        assert_eq!(ms.match_at(s).unwrap(), Some(e));
+        match ms.get_onecapture(0, s, e).unwrap() {
+            CapValue::Str { start, end } => assert_eq!(&src[start..end], b"hello"),
+            _ => panic!(),
+        }
+        match ms.get_onecapture(1, s, e).unwrap() {
+            CapValue::Str { start, end } => assert_eq!(&src[start..end], b"world"),
+            _ => panic!(),
+        }
+        assert_eq!(ms.num_captures(true), 2);
+    }
+
+    #[test]
+    fn position_capture() {
+        let src = b"abc";
+        let pat = b"()b()";
+        let (s, e) = first_match(src, pat).unwrap();
+        let mut ms = MatchState::new(src, pat);
+        ms.match_at(s).unwrap();
+        assert!(matches!(
+            ms.get_onecapture(0, s, e).unwrap(),
+            CapValue::Pos(2)
+        ));
+        assert!(matches!(
+            ms.get_onecapture(1, s, e).unwrap(),
+            CapValue::Pos(3)
+        ));
+    }
+
+    #[test]
+    fn balanced_and_backref() {
+        assert_eq!(whole("(a(b)c)x", "%b()"), Some("(a(b)c)".into()));
+        assert_eq!(whole("hello", "(l)%1"), Some("ll".into()));
+        assert_eq!(whole("abab", "(ab)%1"), Some("abab".into()));
+    }
+
+    #[test]
+    fn frontier() {
+        // %f[%a] matches the empty string before the first alpha run.
+        assert_eq!(first_match(b"  THE", b"%f[%a]"), Some((2, 2)));
+        assert_eq!(first_match(b"123", b"%f[%a]"), None);
+    }
+
+    #[test]
+    fn errors() {
+        // Mirror how the real callbacks surface errors: an error may come from
+        // `match_at` (malformed pattern) or from capture extraction afterward
+        // (`unfinished capture`), exactly as `find`/`match` do.
+        fn err(pat: &[u8]) -> PatError {
+            let anchor = pat.first() == Some(&b'^');
+            let p = if anchor { &pat[1..] } else { pat };
+            let src = b"x";
+            let mut ms = MatchState::new(src, p);
+            let mut s = 0;
+            loop {
+                match ms.match_at(s) {
+                    Err(e) => return e,
+                    Ok(Some(e)) => {
+                        for i in 0..ms.num_captures(true) {
+                            if let Err(er) = ms.get_onecapture(i, s, e) {
+                                return er;
+                            }
+                        }
+                        unreachable!("expected error, matched cleanly");
+                    }
+                    Ok(None) => {}
+                }
+                if s >= src.len() {
+                    unreachable!("expected error, no match");
+                }
+                s += 1;
+            }
+        }
+        assert_eq!(err(b"("), PatError::UnfinishedCapture);
+        assert_eq!(err(b"%"), PatError::EndsWithPercent);
+        assert_eq!(err(b"["), PatError::MissingBracket);
+        assert_eq!(err(b"%1"), PatError::InvalidCaptureIndex(1));
+        assert_eq!(err(b"%f"), PatError::MissingFrontierBracket);
+        assert_eq!(err(b"%b"), PatError::BalanceArgs);
+    }
+
+    #[test]
+    fn nospecials_check() {
+        assert!(nospecials(b"hello"));
+        assert!(nospecials(b"a/b/c"));
+        assert!(!nospecials(b"a.b"));
+        assert!(!nospecials(b"a%d"));
+        assert!(nospecials(b"")); // empty pattern is plain
+    }
+
+    #[test]
+    fn plain_find_check() {
+        assert_eq!(plain_find(b"a.b.c", b"."), Some(1));
+        assert_eq!(plain_find(b"abc", b""), Some(0));
+        assert_eq!(plain_find(b"abc", b"bc"), Some(1));
+        assert_eq!(plain_find(b"abc", b"d"), None);
+        assert_eq!(plain_find(b"abc", b"abcd"), None);
+    }
+}

--- a/src/lua/executor.rs
+++ b/src/lua/executor.rs
@@ -832,7 +832,11 @@ fn land_call_results<'gc>(ts: &mut crate::env::thread::ThreadState<'gc>, cs: Cal
         ts.stack[func_idx + i] = Value::nil();
     }
     if returns == 0 {
+        // MULTRET: publish the dynamic top for the next consumer, mirroring
+        // the inline native-return path in `op_call` (a fixed-results call
+        // reads registers, not `top`, so only this branch must set it).
         ts.stack.truncate(func_idx + retc);
+        ts.top = func_idx + retc;
     } else {
         // Keep stack >= func_idx + wanted; restore caller's max_stack_size
         // window if a Lua frame is on top.

--- a/src/parser/kind.rs
+++ b/src/parser/kind.rs
@@ -193,8 +193,14 @@ pub enum SyntaxKind {
     #[token("false")]
     False,
 
-    #[regex(r#""(\\[\\"]|[^"])*""#)]
-    #[regex(r#"'(\\[\\']|[^'])*'"#)]
+    // A backslash always begins a two-char escape unit (`\\` followed by any
+    // byte, newline included); the unescaped branch must therefore exclude
+    // backslash. Decoding the escape happens later — the regex only needs to
+    // find the string's bounds. Letting the unescaped branch match `\` made a
+    // literal ending in `\\` ambiguous, and maximal munch swallowed the next
+    // string's opening quote (`"a\\", "x"` tokenized as one string).
+    #[regex(r#""(\\[\s\S]|[^"\\])*""#)]
+    #[regex(r#"'(\\[\s\S]|[^'\\])*'"#)]
     String,
 
     #[regex(r"\[=*\[", long_string)]

--- a/src/vm/interp.rs
+++ b/src/vm/interp.rs
@@ -2699,7 +2699,7 @@ pub(crate) fn close_upvalues<'gc>(
 const MAX_TAG_LOOP: usize = 2000;
 
 /// Result of walking an `__index` chain.
-enum IndexChain<'gc> {
+pub(crate) enum IndexChain<'gc> {
     /// The chain resolved synchronously to a value (possibly `Nil`).
     Resolved(Value<'gc>),
     /// The chain ended in a callable that must be invoked with
@@ -2721,7 +2721,7 @@ enum IndexChain<'gc> {
 /// `luaV_finishget`). `mm_index_name` is the pre-interned `__index`
 /// LuaString — the function never re-interns it.
 #[inline]
-fn walk_index_chain<'gc>(
+pub(crate) fn walk_index_chain<'gc>(
     start_receiver: Value<'gc>,
     start_metatable: Table<'gc>,
     key: Value<'gc>,

--- a/src/vm/interp.rs
+++ b/src/vm/interp.rs
@@ -2118,7 +2118,7 @@ extern "rust-preserve-none" fn op_setlist<'gc>(
     instruction: Instruction,
     ctx: Context<'gc>,
     thread: &mut ThreadState<'gc>,
-    registers: Registers<'gc, '_>,
+    mut registers: Registers<'gc, '_>,
     mut ip: *const Instruction,
     handlers: *const (),
 ) -> Result<(), Box<Error>> {
@@ -2133,7 +2133,10 @@ extern "rust-preserve-none" fn op_setlist<'gc>(
     };
     // `count == 0` is MULTRET: element count comes from `thread.top`. It can
     // exceed u8 (a `VARARG count=0` spread), so index the stack by usize.
-    let base = thread.top_lua().unwrap().base;
+    let (base, max_stack) = {
+        let f = thread.top_lua().unwrap();
+        (f.base, f.closure.proto.max_stack_size as usize)
+    };
     let elements_start = base + table as usize + 1;
     let n = if count == 0 {
         thread.top - elements_start
@@ -2145,6 +2148,18 @@ extern "rust-preserve-none" fn op_setlist<'gc>(
         let val = thread.stack[elements_start + i - 1];
         let key = Value::integer(off + i as i64);
         t.raw_set(ctx, key, val);
+    }
+    if count == 0 {
+        // A MULTRET spread leaves `thread.stack` truncated to `thread.top` by
+        // the producer (e.g. a native call's variadic return). Restore the
+        // frame's register window so subsequent fixed-register ops stay in
+        // bounds — mirrors `op_call`'s post-return restore (PUC's
+        // `L->top = ci->top`). A resize may reallocate, so refresh `registers`.
+        let needed = base + max_stack;
+        if thread.stack.len() < needed {
+            thread.stack.resize(needed, Value::nil());
+            registers = unsafe { thread.stack.as_mut_ptr().add(base) };
+        }
     }
     dispatch!();
 }


### PR DESCRIPTION
Implements the Lua pattern engine from issue #27: `string.find`, `string.match`, `string.gmatch`, and `string.gsub`.

## What's here

- **`src/builtin/string/pattern.rs`** — a standalone, GC-free port of PUC-Lua 5.5.0's `lstrlib.c` matcher (`match`, `classend`, `singlematch`, `max_expand`/`min_expand`, captures, `%b`, `%f`, back-references), with C-locale `ctype` semantics and 12 unit tests. `string.rs` becomes a `string/` module so the engine is a sibling.
- **`find`** — plain or pattern search; 1-based start/end indices plus captures. Plain search on explicit `plain=true` or a pattern with no magic chars.
- **`match`** — first match's captures (or the whole match when there are none).
- **`gmatch`** — a stateful iterator closure backed by a `RefCell<GmatchState>` userdata (a leading `^` is a literal here, matching reference).
- **`gsub`** — string/number replacers resolve synchronously; table/function replacers re-enter the interpreter via an async `Sequence` (the same mechanism `table.sort` uses). Table indexing honors `__index` (table chains and function `__index`), reusing the interpreter's `walk_index_chain`.

## Incidental VM/lexer fixes

These are pre-existing bugs (reproducible without patterns) that the pattern work depended on or surfaced:

- **`op_setlist` MULTRET window restore** — `{native_fn(...)}` (e.g. the canonical `local t = {string.match(s, p)}` capture idiom, or `{table.unpack(...)}`) built the table correctly but left the frame's register window truncated, so later fixed-register reads dropped a value or panicked. Now restores the window after a variadic spread, mirroring `op_call`.
- **`land_call_results` MULTRET top** — the Sequence-return path didn't publish `thread.top` for a MULTRET caller, so `print(gsub(...))` corrupted the stack (this also fixes the previously-seen `print(coroutine.resume(...))` overflow).
- **Lexer trailing-backslash** — string literals ending in `\` followed by another literal merged tokens (`print("a\\", "x")` errored/hung). A backslash now always begins a two-char escape unit; the unescaped branch excludes it. All escape decoding is unchanged.
