### PR TITLE
lexer: fix \u{} unicode escape decoding

### DIFF
--- a/src/parser/lit.rs
+++ b/src/parser/lit.rs
@@ -53,11 +53,14 @@ pub fn parse_hex_float(s: &str) -> Option<f64> {
     Some(value)
 }
 
-pub fn parse_string(s: &str) -> Vec<u8> {
+/// Decode a quoted string literal (including the surrounding quotes). Returns
+/// `None` on a malformed escape (a too-large decimal/`\u{}` value) so the
+/// caller can surface a parse error instead of the decoder panicking.
+pub fn parse_string(s: &str) -> Option<Vec<u8>> {
     parse_string_fragment(&s[1..s.len() - 1])
 }
 
-pub fn parse_long_string(s: &str) -> Vec<u8> {
+pub fn parse_long_string(s: &str) -> Option<Vec<u8>> {
     let mut suffix = 1;
     let mut s = &s[1..s.len() - 1];
 
@@ -119,7 +122,7 @@ enum StringToken {
     Unicode,
 }
 
-fn parse_string_fragment(s: &str) -> Vec<u8> {
+fn parse_string_fragment(s: &str) -> Option<Vec<u8>> {
     let b = s.as_bytes();
     let mut bytes = Vec::new();
 
@@ -138,68 +141,148 @@ fn parse_string_fragment(s: &str) -> Vec<u8> {
             Ok(StringToken::LeftBracket) => bytes.push(0x5B),
             Ok(StringToken::RightBracket) => bytes.push(0x5D),
             Ok(StringToken::Hex) => parse_hex_escape(&mut bytes, &s[span]),
-            Ok(StringToken::Decimal) => parse_decimal_escape(&mut bytes, &s[span]),
-            Ok(StringToken::Unicode) => parse_unicode_escape(&mut bytes, &s[span]),
+            Ok(StringToken::Decimal) => parse_decimal_escape(&mut bytes, &s[span])?,
+            Ok(StringToken::Unicode) => parse_unicode_escape(&mut bytes, &s[span])?,
             Err(()) => bytes.extend_from_slice(&b[span]),
         }
     }
 
-    bytes
+    Some(bytes)
 }
 
 fn parse_hex_escape(dst: &mut Vec<u8>, s: &str) {
-    let char = u8::from_str_radix(&s[2..], 16).unwrap();
+    // The `\xHH` regex guarantees exactly two hex digits, so this fits a `u8`.
+    let char = u8::from_str_radix(&s[2..], 16).expect("\\x escape has two hex digits");
     dst.push(char);
 }
 
-fn parse_decimal_escape(dst: &mut Vec<u8>, s: &str) {
-    let char = s[1..].parse::<u8>().unwrap();
+fn parse_decimal_escape(dst: &mut Vec<u8>, s: &str) -> Option<()> {
+    // `\ddd` is 1–3 decimal digits; Lua rejects a value > 255 (`None` here so
+    // the caller raises a parse error rather than the decoder panicking).
+    let char = s[1..].parse::<u8>().ok()?;
     dst.push(char);
+    Some(())
 }
 
-fn parse_unicode_escape(dst: &mut Vec<u8>, s: &str) {
-    let codepoint = u32::from_str_radix(&s[2..s.len() - 1], 16).unwrap();
-    let ch = char::from_u32(codepoint).unwrap();
-    let buf = &mut [0; 4];
-    let subs = ch.encode_utf8(buf).as_bytes();
-    dst.extend_from_slice(subs);
+fn parse_unicode_escape(dst: &mut Vec<u8>, s: &str) -> Option<()> {
+    // `s` is `\u{HEX}`; skip the 3-byte `\u{` prefix and the trailing `}`.
+    let hex = &s[3..s.len() - 1];
+    // Parse into `u64` so an over-long digit run yields `None` rather than
+    // overflow-panicking. Lua accepts code points up to 0x7FFFFFFF.
+    let cp = u64::from_str_radix(hex, 16).ok()?;
+    if cp > 0x7FFF_FFFF {
+        return None; // Lua: "UTF-8 value too large"
+    }
+    utf8_encode(dst, cp as u32);
+    Some(())
+}
+
+/// Lua's `luaO_utf8esc`: encode a code point (0..=0x7FFFFFFF) as 1–6 bytes via
+/// the original, pre-Unicode UTF-8 scheme. Unlike `char::encode_utf8`, this
+/// emits surrogates (U+D800..U+DFFF) and values beyond U+10FFFF verbatim, which
+/// is what `\u{...}` does in lua 5.5.
+fn utf8_encode(dst: &mut Vec<u8>, cp: u32) {
+    if cp < 0x80 {
+        dst.push(cp as u8);
+        return;
+    }
+    const SZ: usize = 8;
+    let mut buff = [0u8; SZ];
+    let mut x = cp;
+    let mut n = 1usize;
+    let mut mfb: u32 = 0x3f; // max value representable in the lead byte
+    loop {
+        buff[SZ - n] = (0x80 | (x & 0x3f)) as u8; // a continuation byte
+        n += 1;
+        x >>= 6;
+        mfb >>= 1; // one fewer bit available in the lead byte each round
+        if x <= mfb {
+            break;
+        }
+    }
+    buff[SZ - n] = ((!mfb << 1) | x) as u8; // lead byte: count marker + residue
+    dst.extend_from_slice(&buff[SZ - n..]);
 }
 
 #[cfg(test)]
 mod tests {
     use super::parse_string;
 
+    fn parse(s: &str) -> Vec<u8> {
+        super::parse_string(s).expect("well-formed literal")
+    }
+
     // `parse_string` expects the surrounding quotes; the raw strings below are
     // the literal source bytes, so `r#""\195\169""#` is the Lua literal "\195\169".
     #[test]
     fn decimal_escape_multibyte() {
-        assert_eq!(parse_string(r#""\195\169""#), vec![195, 169]);
+        assert_eq!(parse(r#""\195\169""#), vec![195, 169]);
     }
 
     #[test]
     fn decimal_escape_ascii() {
-        assert_eq!(parse_string(r#""\65\66\67""#), b"ABC");
+        assert_eq!(parse(r#""\65\66\67""#), b"ABC");
     }
 
     #[test]
     fn decimal_escape_embedded_nul() {
-        assert_eq!(parse_string(r#""a\0b""#), vec![b'a', 0, b'b']);
+        assert_eq!(parse(r#""a\0b""#), vec![b'a', 0, b'b']);
     }
 
     #[test]
     fn decimal_escape_is_greedy_then_literal() {
         // `\065` munches three digits (= 65, 'A'), leaving '3' as a literal.
-        assert_eq!(parse_string(r#""\0653""#), vec![65, b'3']);
+        assert_eq!(parse(r#""\0653""#), vec![65, b'3']);
     }
 
     #[test]
     fn decimal_escape_does_not_cross_escaped_backslash() {
         // `\\` is one escaped backslash; the following `65` stay literal.
-        assert_eq!(parse_string(r#""\\65""#), vec![b'\\', b'6', b'5']);
+        assert_eq!(parse(r#""\\65""#), vec![b'\\', b'6', b'5']);
     }
 
     #[test]
     fn decimal_escape_max_byte() {
-        assert_eq!(parse_string(r#""\255""#), vec![255]);
+        assert_eq!(parse(r#""\255""#), vec![255]);
+    }
+
+    #[test]
+    fn decimal_escape_too_large_is_none() {
+        // `\256` > 255 — a parse error, not a decoder panic.
+        assert_eq!(parse_string(r#""\256""#), None);
+    }
+
+    // Unicode escapes use Lua's extended UTF-8 (`luaO_utf8esc`): up to 6 bytes,
+    // code points to 0x7FFFFFFF, surrogates and beyond-U+10FFFF included.
+    // Expected bytes cross-checked against lua 5.5.0.
+    #[test]
+    fn unicode_escape_ascii() {
+        assert_eq!(parse(r#""\u{48}""#), vec![0x48]); // 'H'
+        assert_eq!(parse(r#""\u{0}""#), vec![0]);
+        assert_eq!(parse(r#""\u{00048}""#), vec![0x48]); // leading zeros
+    }
+
+    #[test]
+    fn unicode_escape_multibyte() {
+        assert_eq!(parse(r#""\u{E9}""#), vec![0xC3, 0xA9]); // é
+        assert_eq!(parse(r#""\u{20AC}""#), vec![0xE2, 0x82, 0xAC]); // €
+        assert_eq!(parse(r#""\u{1F600}""#), vec![0xF0, 0x9F, 0x98, 0x80]); // emoji
+    }
+
+    #[test]
+    fn unicode_escape_surrogates_and_beyond_unicode() {
+        assert_eq!(parse(r#""\u{D800}""#), vec![0xED, 0xA0, 0x80]); // surrogate
+        assert_eq!(parse(r#""\u{110000}""#), vec![0xF4, 0x90, 0x80, 0x80]);
+        // 0x7FFFFFFF — the maximum Lua accepts — encodes to 6 bytes.
+        assert_eq!(
+            parse(r#""\u{7FFFFFFF}""#),
+            vec![0xFD, 0xBF, 0xBF, 0xBF, 0xBF, 0xBF]
+        );
+    }
+
+    #[test]
+    fn unicode_escape_too_large_is_none() {
+        assert_eq!(parse_string(r#""\u{80000000}""#), None); // > 0x7FFFFFFF
+        assert_eq!(parse_string(r#""\u{FFFFFFFFF}""#), None); // overflows
     }
 }

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -290,8 +290,8 @@ impl Literal {
             T![hex_int] => LiteralValue::Int(lit::parse_hex_int(s).ok()?),
             T![float] => LiteralValue::Float(lit::parse_float(s).ok()?),
             T![hex_float] => LiteralValue::Float(lit::parse_hex_float(s)?),
-            T![string] => LiteralValue::String(lit::parse_string(s)),
-            T![long_string] => LiteralValue::String(lit::parse_long_string(s)),
+            T![string] => LiteralValue::String(lit::parse_string(s)?),
+            T![long_string] => LiteralValue::String(lit::parse_long_string(s)?),
             _ => unreachable!(),
         })
     }


### PR DESCRIPTION
Fixes `\u{...}` Unicode string escapes, which panicked on every use.

## The bug

`parse_unicode_escape` sliced `s[2..]`, but the `\u{` prefix is 3 bytes — so it parsed `{NN` as hex and panicked with `ParseIntError` on every `\u{...}` escape (`"\u{48}"` etc.). It also routed the code point through `char::from_u32` + `encode_utf8`, which cannot represent surrogates or code points beyond U+10FFFF.

## The fix

- **Correct the offset** — strip the 3-byte `\u{` prefix and trailing `}`.
- **Extended UTF-8** — port Lua's `luaO_utf8esc`: emit 1–6 bytes for code points up to `0x7FFFFFFF`, encoding surrogates (U+D800..U+DFFF) and values beyond U+10FFFF verbatim, matching `\u{...}` in lua 5.5.
- **Fallible decoder** — the string escape decoder now returns `Option`, so a too-large `\u{...}` (`> 0x7FFFFFFF`) or `\ddd` (`> 255`) becomes a parse error via the existing `Literal::value` → `None` path (a `CompileError`) instead of panicking the process deep in the decoder.

## Verification

Valid `\u{...}` output is byte-identical to reference `lua` 5.5.0 across the full range (ASCII, multibyte, surrogates, beyond-U+10FFFF, the 6-byte max `\u{7FFFFFFF}`). New unit tests cover the valid range, surrogates, and the too-large error cases; the full suite (222 tests), `clippy`, and `fmt` are clean, with no regression on other escapes.

Found while differential-testing the string pattern engine (#106), but unrelated to it — branched off `main`.
