### PR TITLE
compiler: fix free_reg panic on an `and`/`or` binop operand, tighten codegen

### DIFF
--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -831,6 +831,12 @@ impl<'gc, 'a> Ctx<'gc, 'a> {
                 }
             }
             ExprKind::Reg(reg) => {
+                // Mirror Lua's `freeexp` in `jumponcond`: release the operand
+                // temp before recording the TESTSET so the short-circuit value
+                // and the fall-through value materialise into one register (no
+                // orphan, no unifying MOVE). The TESTSET reads `reg` before any
+                // reuse overwrites it (emission order guarantees read-then-load).
+                self.free_reg(reg);
                 let jmp = self.emit_test_jump(reg, false);
                 expr.false_list.jumps.push(jmp);
             }
@@ -869,6 +875,9 @@ impl<'gc, 'a> Ctx<'gc, 'a> {
                 }
             }
             ExprKind::Reg(reg) => {
+                // See `goiftrue`: free the operand temp (Lua's `freeexp`) so the
+                // short-circuit and fall-through values share one register.
+                self.free_reg(reg);
                 let jmp = self.emit_test_jump(reg, true);
                 expr.true_list.jumps.push(jmp);
             }
@@ -2952,11 +2961,25 @@ fn compile_expr_binary_op(
     let lhs_expr = item.lhs().ok_or_else(|| ice("binop without lhs"))?;
     let rhs_expr = item.rhs().ok_or_else(|| ice("binop without rhs"))?;
     let mut lhs_desc = compile_expr(ctx, lhs_expr, None)?;
+
+    // Infix (mirrors Lua's `luaK_infix`): settle the LHS *before* compiling the
+    // RHS, so a jump-carrying RHS (an `and`/`or`/comparison) can't have the
+    // LHS's value-load emitted into its short-circuit span — where the
+    // short-circuit `JMP` would skip it. We keep a foldable numeral LHS lazy so
+    // a numeric RHS can still constant-fold; `CONCAT` is the exception — its
+    // operands must occupy consecutive ascending registers, so its LHS is
+    // materialised here regardless to take the lower register.
+    let lhs_lazy_numeral = matches!(lhs_desc.kind, ExprKind::Numeral(_)) && !lhs_desc.has_jumps();
+    let materialise_lhs_early = op == BinaryOperator::Concat || !lhs_lazy_numeral;
+    if materialise_lhs_early {
+        ctx.discharge_to_reg_mut(&mut lhs_desc, None)?;
+    }
+
     let mut rhs_desc = compile_expr(ctx, rhs_expr, None)?;
 
-    // Constant fold: both operands are numeric literals, op is foldable,
-    // and `validop` (no div-by-zero, no NaN/0 float result, bitwise needs
-    // integer-convertible operands) passes.
+    // Constant fold: both operands are numeric literals, op is foldable, and
+    // `validop` passes. Only reachable when the LHS stayed a lazy numeral
+    // (otherwise its kind is now `Reg` and this match fails).
     if let (ExprKind::Numeral(l), ExprKind::Numeral(r)) = (lhs_desc.kind, rhs_desc.kind)
         && !lhs_desc.has_jumps()
         && !rhs_desc.has_jumps()
@@ -2965,9 +2988,19 @@ fn compile_expr_binary_op(
         return Ok(ExprDesc::from_numeral(folded));
     }
 
-    // Non-fold path: discharge both operands and emit the runtime op.
-    let lhs = ctx.discharge_to_reg_mut(&mut lhs_desc, None)?;
-    let rhs = ctx.discharge_to_reg_mut(&mut rhs_desc, None)?;
+    // Postfix: materialise both operands, then emit. When the LHS is still a
+    // lazy numeral and the RHS carries short-circuit jumps, discharge the RHS
+    // first so the LHS's `LOAD` lands *after* the RHS's jump span (tcvm has no
+    // immediate arithmetic operands, so the constant must occupy a register).
+    let (lhs, rhs) = if !materialise_lhs_early && rhs_desc.has_jumps() {
+        let rhs = ctx.discharge_to_reg_mut(&mut rhs_desc, None)?;
+        let lhs = ctx.discharge_to_reg_mut(&mut lhs_desc, None)?;
+        (lhs, rhs)
+    } else {
+        let lhs = ctx.discharge_to_reg_mut(&mut lhs_desc, None)?;
+        let rhs = ctx.discharge_to_reg_mut(&mut rhs_desc, None)?;
+        (lhs, rhs)
+    };
 
     let reg = match op {
         BinaryOperator::Add => emit_arith(

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_const_fold_branch.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_const_fold_branch.snap
@@ -1,9 +1,9 @@
 ---
 source: src/compiler/snapshot_tests.rs
-assertion_line: 132
+assertion_line: 139
 expression: output
 ---
-; function (params=0, vararg=true, stack=2, upvalues=1)
+; function (params=0, vararg=true, stack=1, upvalues=1)
 ; constants:
 ;   K0 = "a"
 ;   K1 = 1
@@ -23,10 +23,10 @@ expression: output
 0003  LOAD            R0 K2  ; false
 0004  TEST            R0 inv=false
 0005  JMP             +2
-0006  LOAD            R1 K4  ; 2
-0007  SETTABUP        R1 U0 K3  ; "b"
-0008  LOAD            R1 K6  ; 5
-0009  SETTABUP        R1 U0 K5  ; "c"
-0010  LOAD            R1 K8  ; 7
-0011  SETTABUP        R1 U0 K7  ; "d"
+0006  LOAD            R0 K4  ; 2
+0007  SETTABUP        R0 U0 K3  ; "b"
+0008  LOAD            R0 K6  ; 5
+0009  SETTABUP        R0 U0 K5  ; "c"
+0010  LOAD            R0 K8  ; 7
+0011  SETTABUP        R0 U0 K7  ; "d"
 0012  RETURN          R0 count=1

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_freereg_discarded_call.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_freereg_discarded_call.snap
@@ -1,9 +1,9 @@
 ---
 source: src/compiler/snapshot_tests.rs
-assertion_line: 86
+assertion_line: 89
 expression: output
 ---
-; function (params=0, vararg=true, stack=5, upvalues=1)
+; function (params=0, vararg=true, stack=4, upvalues=1)
 ; constants:
 ;   K0 = 1
 ;   K1 = 2
@@ -21,10 +21,10 @@ expression: output
 0008  NOT             R3 R1
 0009  TEST            R3 inv=false
 0010  JMP             +2
-0011  LOAD            R4 K0  ; 1
-0012  RETURN          R4 count=2
-0013  ADD             R4 R1 R2
-0014  RETURN          R4 count=2
+0011  LOAD            R3 K0  ; 1
+0012  RETURN          R3 count=2
+0013  ADD             R3 R1 R2
+0014  RETURN          R3 count=2
 
 ; prototype 0:
   ; function (params=0, vararg=false, stack=0, upvalues=0)

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_issue_65_conditional_return.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_issue_65_conditional_return.snap
@@ -1,9 +1,9 @@
 ---
 source: src/compiler/snapshot_tests.rs
-assertion_line: 72
+assertion_line: 71
 expression: output
 ---
-; function (params=0, vararg=true, stack=4, upvalues=1)
+; function (params=0, vararg=true, stack=3, upvalues=1)
 ; constants:
 ;   K0 = 1
 ; upvalues:
@@ -17,8 +17,8 @@ expression: output
 0005  NOT             R2 R1
 0006  TEST            R2 inv=false
 0007  JMP             +2
-0008  LOAD            R3 K0  ; 1
-0009  RETURN          R3 count=2
+0008  LOAD            R2 K0  ; 1
+0009  RETURN          R2 count=2
 0010  RETURN          R0 count=1
 
 ; prototype 0:

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_nbody.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_nbody.snap
@@ -1,5 +1,6 @@
 ---
 source: src/compiler/snapshot_tests.rs
+assertion_line: 78
 expression: output
 ---
 ; function (params=0, vararg=true, stack=23, upvalues=1)
@@ -164,61 +165,60 @@ expression: output
 0102  GETTABUP        R13 U0 K42  ; "arg"
 0103  TEST            R13 inv=false
 0104  JMP             +3
-0105  GETTABUP        R14 U0 K42  ; "arg"
-0106  LOAD            R15 K43  ; 1
-0107  GETTABLE        R13 R14 R15
+0105  GETTABUP        R13 U0 K42  ; "arg"
+0106  LOAD            R14 K43  ; 1
+0107  GETTABLE        R13 R13 R14
 0108  CALL            R12 args=2 ret=2
-0109  TESTSET         R13 R12 inv=false
+0109  TEST            R12 inv=true
 0110  JMP             +1
-0111  LOAD            R13 K44  ; 1000
-0112  MOVE            R12 R13
-0113  NEWTABLE        R13
-0114  MOVE            R14 R8
-0115  MOVE            R15 R4
-0116  MOVE            R16 R5
-0117  MOVE            R17 R6
-0118  MOVE            R18 R7
-0119  SETLIST         R13 count=5 offset=0
-0120  LEN             R14 R13
-0121  MOVE            R15 R11
-0122  MOVE            R16 R13
-0123  MOVE            R17 R14
-0124  CALL            R15 args=3 ret=1
-0125  GETTABUP        R15 U0 K45  ; "io"
-0126  GETFIELD        R15 R15 K46  ; "write"
-0127  GETTABUP        R16 U0 K47  ; "string"
-0128  GETFIELD        R16 R16 K48  ; "format"
-0129  LOAD            R17 K49  ; "%0.9f"
-0130  MOVE            R18 R10
-0131  MOVE            R19 R13
-0132  MOVE            R20 R14
-0133  CALL            R18 args=3 ret=0
-0134  CALL            R16 args=0 ret=2
-0135  LOAD            R17 K50  ; "\n"
-0136  CALL            R15 args=3 ret=1
-0137  LOAD            R15 K43  ; 1
-0138  MOVE            R16 R12
-0139  LOAD            R17 K43  ; 1
-0140  FORPREP         R15 +6
-0141  MOVE            R19 R9
-0142  MOVE            R20 R13
-0143  MOVE            R21 R14
-0144  LOAD            R22 K51  ; 0.01
-0145  CALL            R19 args=4 ret=1
-0146  FORLOOP         R15 -6
-0147  GETTABUP        R15 U0 K45  ; "io"
-0148  GETFIELD        R15 R15 K46  ; "write"
-0149  GETTABUP        R16 U0 K47  ; "string"
-0150  GETFIELD        R16 R16 K48  ; "format"
-0151  LOAD            R17 K49  ; "%0.9f"
-0152  MOVE            R18 R10
-0153  MOVE            R19 R13
-0154  MOVE            R20 R14
-0155  CALL            R18 args=3 ret=0
-0156  CALL            R16 args=0 ret=2
-0157  LOAD            R17 K50  ; "\n"
-0158  CALL            R15 args=3 ret=1
-0159  RETURN          R0 count=1
+0111  LOAD            R12 K44  ; 1000
+0112  NEWTABLE        R13
+0113  MOVE            R14 R8
+0114  MOVE            R15 R4
+0115  MOVE            R16 R5
+0116  MOVE            R17 R6
+0117  MOVE            R18 R7
+0118  SETLIST         R13 count=5 offset=0
+0119  LEN             R14 R13
+0120  MOVE            R15 R11
+0121  MOVE            R16 R13
+0122  MOVE            R17 R14
+0123  CALL            R15 args=3 ret=1
+0124  GETTABUP        R15 U0 K45  ; "io"
+0125  GETFIELD        R15 R15 K46  ; "write"
+0126  GETTABUP        R16 U0 K47  ; "string"
+0127  GETFIELD        R16 R16 K48  ; "format"
+0128  LOAD            R17 K49  ; "%0.9f"
+0129  MOVE            R18 R10
+0130  MOVE            R19 R13
+0131  MOVE            R20 R14
+0132  CALL            R18 args=3 ret=0
+0133  CALL            R16 args=0 ret=2
+0134  LOAD            R17 K50  ; "\n"
+0135  CALL            R15 args=3 ret=1
+0136  LOAD            R15 K43  ; 1
+0137  MOVE            R16 R12
+0138  LOAD            R17 K43  ; 1
+0139  FORPREP         R15 +6
+0140  MOVE            R19 R9
+0141  MOVE            R20 R13
+0142  MOVE            R21 R14
+0143  LOAD            R22 K51  ; 0.01
+0144  CALL            R19 args=4 ret=1
+0145  FORLOOP         R15 -6
+0146  GETTABUP        R15 U0 K45  ; "io"
+0147  GETFIELD        R15 R15 K46  ; "write"
+0148  GETTABUP        R16 U0 K47  ; "string"
+0149  GETFIELD        R16 R16 K48  ; "format"
+0150  LOAD            R17 K49  ; "%0.9f"
+0151  MOVE            R18 R10
+0152  MOVE            R19 R13
+0153  MOVE            R20 R14
+0154  CALL            R18 args=3 ret=0
+0155  CALL            R16 args=0 ret=2
+0156  LOAD            R17 K50  ; "\n"
+0157  CALL            R15 args=3 ret=1
+0158  RETURN          R0 count=1
 
 ; prototype 0:
   ; function (params=3, vararg=false, stack=29, upvalues=1)

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_not_andor.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_not_andor.snap
@@ -1,8 +1,9 @@
 ---
 source: src/compiler/snapshot_tests.rs
+assertion_line: 152
 expression: output
 ---
-; function (params=0, vararg=true, stack=14, upvalues=1)
+; function (params=0, vararg=true, stack=13, upvalues=1)
 ; constants:
 ;   K0 = 1
 ;   K1 = 2
@@ -56,11 +57,11 @@ expression: output
 0040  NOT             R8 R1
 0041  TEST            R8 inv=false
 0042  JMP             +2
-0043  LOAD            R9 K5  ; 0
-0044  RETURN          R9 count=2
-0045  MOVE            R9 R3
-0046  MOVE            R10 R4
-0047  MOVE            R11 R5
-0048  MOVE            R12 R6
-0049  MOVE            R13 R7
-0050  RETURN          R9 count=6
+0043  LOAD            R8 K5  ; 0
+0044  RETURN          R8 count=2
+0045  MOVE            R8 R3
+0046  MOVE            R9 R4
+0047  MOVE            R10 R5
+0048  MOVE            R11 R6
+0049  MOVE            R12 R7
+0050  RETURN          R8 count=6

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_primes.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_primes.snap
@@ -1,6 +1,6 @@
 ---
 source: src/compiler/snapshot_tests.rs
-assertion_line: 77
+assertion_line: 80
 expression: output
 ---
 ; function (params=0, vararg=true, stack=6, upvalues=1)
@@ -28,13 +28,13 @@ expression: output
 0010  CALL            R4 args=2 ret=2
 0011  TEST            R4 inv=false
 0012  JMP             +5
-0013  LOAD            R5 K4  ; 1
-0014  ADD             R2 R2 R5
-0015  LOAD            R5 K5  ; "\n"
-0016  CONCAT          R5 R1 R5
-0017  CONCAT          R3 R3 R5
-0018  LOAD            R5 K4  ; 1
-0019  ADD             R1 R1 R5
+0013  LOAD            R4 K4  ; 1
+0014  ADD             R2 R2 R4
+0015  LOAD            R4 K5  ; "\n"
+0016  CONCAT          R4 R1 R4
+0017  CONCAT          R3 R3 R4
+0018  LOAD            R4 K4  ; 1
+0019  ADD             R1 R1 R4
 0020  JMP             -16
 0021  GETTABUP        R4 U0 K6  ; "print"
 0022  MOVE            R5 R3


### PR DESCRIPTION
## Summary

Fixes #110. Compiling a binary expression whose operand is an `a and b or c` short-circuit expression could panic on the `free_reg` LIFO assertion (`rules.rs:391`) during `Context::load` — e.g. `"x" .. (c and 2 or 3)` or `"x" + (c and 2 or 3)`. Both are valid Lua 5.5 that the reference compiler accepts.

## Root cause

`goiffalse`/`goiftrue` materialised the short-circuit operand into a register but never freed it (Lua's `jumponcond` does `freeexp`). The fall-through value then took a *different* register, orphaning the first one and drifting `freereg` — which an enclosing `free_regs(lhs, rhs)` later tripped over.

## Fix

- **`freeexp` in `goiffalse`/`goiftrue`** — release the operand temp after recording the `TESTSET`, so the short-circuit value and the fall-through value materialise into a single register (no orphan, no unifying `MOVE`).
- **Infix/postfix operand ordering in `compile_expr_binary_op`** — settle the LHS *before* compiling the RHS (mirroring Lua's `luaK_infix`), so a jump-carrying RHS can't have the LHS's value-`LOAD` emitted into its short-circuit span (where the short-circuit `JMP` would skip it). `CONCAT` materialises its LHS first to take the lower of its required consecutive registers; a foldable numeral LHS stays lazy so numeric folds still apply; and a lazy-numeral LHS paired with a jump-carrying RHS discharges the RHS first (tcvm has no immediate-arith instruction like luac's `ADDI`).

## Codegen also gets tighter

Beyond fixing the panic, this removes the extra register + `MOVE` the old path emitted:

- `local x = (c and 2 or 3)`: **8 instrs + `MOVE` (stack 3) → 6 instrs, one register, read-only `TEST` (stack 2)** — luac parity.
- All 6 updated snapshots shrink; e.g. `nbody` loses a `LOAD`+`MOVE` pair and a `TESTSET` becomes a read-only `TEST`; smaller stacks across the board.

## Validation

- All **153 lib tests + every integration test pass**.
- Verified **byte-identical to lua 5.5.0** across: a 29-case and/or battery (value/control/nested/mixed-operand contexts), a 30-case full-binop battery (arithmetic/bitwise/concat-chains/comparisons/nested), and the runnable `test-files/` set (**44/44**, the lone differ is a pre-existing global-declaration gap present on `main`; 11 skipped for unrelated unimplemented features).
- `nbody` and `primes` runtime output identical to reference despite the codegen change.
- The original panic repros (`"x"..(c and 2 or 3)`, `"x" + (c and 2 or 3)`, 3-operand concat) now compile and run correctly.
