### PR TITLE
compiler: fix over-broad jump-elision label assert on empty nested ifs

### DIFF
--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -611,9 +611,20 @@ impl<'gc, 'a> Ctx<'gc, 'a> {
                 !self.chunk.jump_patches.iter().any(|&(idx, _)| idx >= j - 1),
                 "no-op jump elision would orphan a pending jump_patch"
             );
+            // Only a *live* label — one a jump_patch resolves at assemble time
+            // — can be orphaned; dead labels (e.g. the unused end_label of an
+            // empty `if ... then end` with no else) are never read. A live
+            // target at exactly `j - 1` is fine: it slides forward onto the
+            // next emitted instruction. A live target past `j - 1` would point
+            // into the elided pair, which can't happen because labels resolve
+            // to statement boundaries, never between a condition's TEST and JMP.
             debug_assert!(
-                !self.chunk.labels.iter().any(|&target| target >= j - 1),
-                "no-op jump elision would orphan a label target"
+                !self
+                    .chunk
+                    .jump_patches
+                    .iter()
+                    .any(|&(_, lbl)| self.chunk.labels[lbl as usize] > j - 1),
+                "no-op jump elision would orphan a live jump target"
             );
             self.chunk.tape.truncate(j - 1);
             list.jumps.remove(pos);

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -151,3 +151,5 @@ test!(
 test!(method_call, "test-files/method_call.lua");
 test!(not_andor, "test-files/not_andor.lua");
 test!(jmp_elim, "test-files/jmp_elim.lua");
+test!(if_empty_nested, "test-files/if_empty_nested.lua");
+test!(if_empty_goto, "test-files/if_empty_goto.lua");

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_if_empty_goto.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_if_empty_goto.snap
@@ -1,0 +1,14 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=1, upvalues=1)
+; constants:
+;   K0 = nil
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  LOAD            R0 K0  ; nil
+0002  JMP             +0
+0003  RETURN          R0 count=1

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_if_empty_nested.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_if_empty_nested.snap
@@ -1,0 +1,15 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=3, upvalues=1)
+; constants:
+;   K0 = nil
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  LOAD            R0 K0  ; nil
+0002  LOAD            R1 K0  ; nil
+0003  LOAD            R2 K0  ; nil
+0004  RETURN          R0 count=1

--- a/test-files/if_empty_goto.lua
+++ b/test-files/if_empty_goto.lua
@@ -1,0 +1,6 @@
+-- A live label (forward goto) set to exactly the elision boundary must
+-- survive: ::skip:: slides forward onto the next emitted instruction.
+local a
+goto skip
+::skip::
+if a then end

--- a/test-files/if_empty_nested.lua
+++ b/test-files/if_empty_nested.lua
@@ -1,0 +1,7 @@
+-- Empty then-blocks: the condition's TEST/JMP elides to a no-op tail.
+-- Nested and sibling empty ifs left dead end_labels that tripped the
+-- over-broad jump-elision assert in patch_to_here (rules.rs:614).
+local a, b, c
+if a then if b then if c then end end end
+if a then end
+if b then end


### PR DESCRIPTION
## Problem

`patch_to_here` elides a trailing no-op `TEST; JMP` pair when an `if`/`elseif` has an empty then-block. The `debug_assert!` guarding that elision (rules.rs:614) rejected it whenever **any** label pointed at `>= j - 1`, which panics on valid Lua:

```lua
local a, b
if a then if b then end end   -- panic: "no-op jump elision would orphan a label target"
```

A sweep found 13 distinct valid snippets that hit it (nested/sibling empty ifs, `for`/`while`/`repeat` bodies, `and`/`or` conditions, `::label::` inside an empty if).

## Root cause

The check was over-conservative on two counts:

1. **It inspected dead labels.** The actual trigger is the inner `if`'s `end_label`, which is never resolved — `assemble()` only patches a label if a `jump_patch` references it, and a no-`else` `if` emits no jump to its end label.
2. **It used `>=`.** A *live* label can legitimately sit exactly at the boundary `j - 1` (the statement boundary before the elided condition) and slides forward onto the next emitted instruction.

This was **debug-only**: `--release` (and `luac5.5`) produce correct bytecode for every affected case. A genuine orphan needs a live label with `target > j - 1` (pointing at the elided `JMP`), which is structurally impossible — labels resolve to statement boundaries, never between a condition's `TEST` and its `JMP`.

## Fix

Scope the assert to **live** targets (those a `jump_patch` resolves) with strict **`>`**, and update the explaining comment. The companion `jump_patches` assert (L610) is unchanged — it never fires.

## Tests

Two snapshot regression tests:

- `if_empty_nested.lua` — nested + sibling empty ifs (the dead-label half).
- `if_empty_goto.lua` — `goto skip; ::skip::; if a then end`, a live label at the boundary (the strict-`>` half).

Full lib suite: **155 passed, 0 failed**; no existing snapshot changed, confirming the change is assert-only.
