### PR TITLE
compiler: lexically scope Lua 5.5 `global` declarations

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use tcvm::env::{LuaString, Table, Value};
-use tcvm::{Executor, Lua, RuntimeError, format_prototype};
+use tcvm::{Executor, LoadError, Lua, RuntimeError, format_prototype};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -18,6 +18,13 @@ struct Args {
     script_args: Vec<String>,
 }
 
+/// Print a clean diagnostic to stderr and exit with failure — used for
+/// load/compile errors so a Lua source error doesn't surface as a panic.
+fn die(e: &dyn std::fmt::Display) -> ! {
+    eprintln!("tcvm: {e}");
+    std::process::exit(1);
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -28,11 +35,14 @@ fn main() {
 
     if args.list {
         let listing = lua.enter(|ctx| {
-            let chunk = ctx.load(&source, Some("test")).unwrap();
+            let chunk = ctx.load(&source, Some("test"))?;
             let closure = chunk.as_lua().expect("loaded chunk must be a Lua closure");
-            format_prototype(&closure.proto)
+            Ok::<_, LoadError>(format_prototype(&closure.proto))
         });
-        print!("{listing}");
+        match listing {
+            Ok(listing) => print!("{listing}"),
+            Err(e) => die(&e),
+        }
         return;
     }
 
@@ -53,10 +63,14 @@ fn main() {
     });
 
     let ex = lua.enter(|ctx| {
-        let chunk = ctx.load(&source, Some("test")).unwrap();
+        let chunk = ctx.load(&source, Some("test"))?;
         let executor = Executor::start(ctx, chunk, ());
-        ctx.stash(executor)
+        Ok::<_, LoadError>(ctx.stash(executor))
     });
+    let ex = match ex {
+        Ok(ex) => ex,
+        Err(e) => die(&e),
+    };
 
     if let Err(e) = lua.execute::<()>(&ex) {
         match e {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -69,6 +69,10 @@ pub struct LexError {}
 pub enum CompileErrorKind {
     #[error("internal compiler error: {0}")]
     Internal(&'static str),
+    #[error("variable '{0}' not declared")]
+    UndeclaredGlobal(String),
+    #[error("attempt to assign to const variable '{0}'")]
+    ConstGlobalAssign(String),
     #[error("insufficient available registers")]
     Registers,
     #[error("too many upvalues")]

--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -174,6 +174,12 @@ enum VarKind {
     /// `args.id` lower to `VARARGGET`; any other use (`local b = args`) or
     /// upvalue capture forces materialization (see [`VarargInfo`]).
     VarargParam,
+    /// A `global Name` declaration in scope (no register). Lives in the
+    /// lexical scope stack purely so it shadows an enclosing `local`/upvalue
+    /// of the same name with correct lexical recency (`manual.of:251-253`);
+    /// the name's kind/declared-ness is tracked on `Ctx::globals`. References
+    /// resolving to this fall through to global (`_ENV`) resolution.
+    Global,
 }
 
 impl VarKind {
@@ -1236,6 +1242,12 @@ impl<'gc, 'a> UpvalueResolver for Ctx<'gc, 'a> {
         if let Some(data) = self.resolve_local(name) {
             let kind = data.kind;
             let register = data.register;
+            // A `global` decl in scope here shadows anything more outer and
+            // is not a capturable local — the child reaches its own global
+            // resolution (`manual.of:251-253`).
+            if matches!(kind, VarKind::Global) {
+                return None;
+            }
             if let VarKind::Const(Some(v)) = kind {
                 return Some(ChildResolution::Const(v));
             }
@@ -1777,10 +1789,17 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
             .to_string();
 
         // Register first so the body can reference it as a declared
-        // global. List-form declarations (this included) void the
-        // implicit `global *` per `manual.of:225-228`.
+        // global (recursion goes through `_ENV`). List-form declarations
+        // (this included) void the implicit `global *` per `manual.of:225-228`.
         ctx.globals.void_preamble();
         ctx.globals.decls.insert(name.clone(), GlobalKind::Reg);
+        ctx.define(
+            name.clone(),
+            VariableData {
+                register: RegisterIndex(0),
+                kind: VarKind::Global,
+            },
+        )?;
 
         // Compile the closure into a register. `compile_func_body`
         // honours the dst hint, so `func_reg == target_reg` (asserted
@@ -1843,10 +1862,9 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
         .collect();
     let values: Vec<Expr> = item.values().map(|v| v.collect()).unwrap_or_default();
 
-    // Register each name *before* compiling initializers so the
-    // initializer expressions see the new declared globals (and so a
-    // self-referential `global X = X` resolves X as declared, not
-    // implicit). Voids the implicit `global *`.
+    // Collect the declared names/kinds (reading the AST only). The
+    // declarations don't take effect until *after* the initializers are
+    // compiled — see below.
     let mut decl_kinds: Vec<(String, GlobalKind)> = Vec::with_capacity(targets.len());
     for target in &targets {
         let name = target
@@ -1862,47 +1880,65 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
         };
         decl_kinds.push((name, kind));
     }
+
+    // Initializer form: lay the value expressions into a contiguous
+    // register block, padding with nil if fewer values than names.
+    // Compile the initializers BEFORE the declarations take effect — a
+    // declaration's scope begins at the *next* statement (`manual.of:245-248`),
+    // so the RHS of `global x = x` (or `global y = y + 1` shadowing an outer
+    // `y`) refers to the outer/undeclared name, not the one being declared.
+    let n_targets = decl_kinds.len();
+    let n_values = values.len();
+    let has_values = !values.is_empty();
+    let value_base = ctx.chunk.freereg;
+    if has_values {
+        for (i, expr) in values.into_iter().enumerate() {
+            let want = RegisterIndex(value_base + i as u8);
+            let got = compile_expr_to_reg(ctx, expr, Some(want))?;
+            if got != want {
+                ctx.emit(Instruction::MOVE {
+                    dst: want.0,
+                    src: got.0,
+                });
+            }
+        }
+        // Pad with nil for any names beyond the supplied values.
+        while ctx.chunk.freereg < value_base + n_targets as u8 {
+            let slot = ctx.reserve_reg()?;
+            let idx = ctx.alloc_constant(Value::nil())?;
+            ctx.emit(Instruction::LOAD { dst: slot.0, idx });
+        }
+        // Drop any extra values past `n_targets` — they were computed
+        // (side-effects preserved) but are unused.
+        if n_values > n_targets {
+            ctx.chunk.freereg = value_base + n_targets as u8;
+        }
+    }
+
+    // The declarations now take effect: void the implicit `global *`, record
+    // the declared names/kinds, and add lexical-scope markers so they shadow
+    // any enclosing local/upvalue of the same name (`manual.of:251-253`).
     ctx.globals.void_preamble();
     for (name, kind) in &decl_kinds {
         ctx.globals.decls.insert(name.clone(), *kind);
+        ctx.define(
+            name.clone(),
+            VariableData {
+                register: RegisterIndex(0),
+                kind: VarKind::Global,
+            },
+        )?;
     }
 
-    if values.is_empty() {
+    if !has_values {
         // No initializer: per `manual.of:1665`, "global variables are
         // left unchanged". Just register the names and emit nothing.
         return Ok(());
     }
 
-    // Initializer form: lay the value expressions into a contiguous
-    // register block, padding with nil if fewer values than names.
-    // Then per name, emit `GETTABUP+ERRNNIL+SETTABUP` taking the value
-    // from the corresponding slot. (Forward order — equivalent to
-    // upstream's reverse-on-unwind emission, just simpler to read.)
-    let n_targets = decl_kinds.len();
-    let n_values = values.len();
-    let value_base = ctx.chunk.freereg;
-    for (i, expr) in values.into_iter().enumerate() {
-        let want = RegisterIndex(value_base + i as u8);
-        let got = compile_expr_to_reg(ctx, expr, Some(want))?;
-        if got != want {
-            ctx.emit(Instruction::MOVE {
-                dst: want.0,
-                src: got.0,
-            });
-        }
-    }
-    // Pad with nil for any names beyond the supplied values.
-    while ctx.chunk.freereg < value_base + n_targets as u8 {
-        let slot = ctx.reserve_reg()?;
-        let idx = ctx.alloc_constant(Value::nil())?;
-        ctx.emit(Instruction::LOAD { dst: slot.0, idx });
-    }
-    // Drop any extra values past `n_targets` — they were computed
-    // (side-effects preserved) but are unused.
-    if n_values > n_targets {
-        ctx.chunk.freereg = value_base + n_targets as u8;
-    }
-
+    // Per name, emit `GETTABUP+ERRNNIL+SETTABUP` taking the value from the
+    // corresponding slot. (Forward order — equivalent to upstream's
+    // reverse-on-unwind emission, just simpler to read.)
     let env_idx = ctx
         .resolve_env_upvalue()
         .ok_or_else(|| ice("_ENV must resolve; main chunk pre-seeds it"))?;
@@ -2092,15 +2128,20 @@ fn compile_lvalue(
             let name = ident
                 .name(ctx.interner)
                 .ok_or_else(|| ice("ident without name"))?;
-            if let Some(data) = ctx.resolve_local(name) {
-                if data.kind.is_const() {
+            // A `global` decl in scope shadows an enclosing local/upvalue of
+            // the same name (manual.of:251-253), so it skips both local and
+            // upvalue resolution and falls through to global resolution.
+            let local = ctx.resolve_local(name).map(|d| (d.kind, d.register));
+            let shadow_global = matches!(local, Some((VarKind::Global, _)));
+            if let Some((kind, register)) = local.filter(|_| !shadow_global) {
+                if kind.is_const() {
                     return Err(err(
                         CompileErrorKind::Internal("assignment to const variable"),
                         LineNumber(0),
                     ));
                 }
-                Ok(Lvalue::Local { dst: data.register })
-            } else if let Some(resolution) = ctx.resolve_or_capture(name) {
+                Ok(Lvalue::Local { dst: register })
+            } else if !shadow_global && let Some(resolution) = ctx.resolve_or_capture(name) {
                 match resolution {
                     ResolvedName::Const(_) => Err(err(
                         CompileErrorKind::Internal("assignment to const variable"),
@@ -2209,6 +2250,9 @@ fn target_local_reg(ctx: &Ctx, target: &Expr) -> Option<u8> {
     };
     let name = ident.name(ctx.interner)?;
     let data = ctx.resolve_local(name)?;
+    if matches!(data.kind, VarKind::Global) {
+        return None;
+    }
     (!data.kind.is_const()).then_some(data.register.0)
 }
 
@@ -2244,7 +2288,7 @@ fn expr_reads(ctx: &Ctx, expr: &Expr, reg: u8) -> Result<bool, CompileError> {
         Expr::Ident(ident) => ident
             .name(ctx.interner)
             .and_then(|n| ctx.resolve_local(n))
-            .is_some_and(|d| d.register.0 == reg),
+            .is_some_and(|d| !matches!(d.kind, VarKind::Global) && d.register.0 == reg),
         Expr::PrefixOp(p) => any(p.rhs())?,
         Expr::BinaryOp(b) => {
             let skip_rhs = matches!(
@@ -2484,9 +2528,12 @@ fn compile_expr_ident(
     // as a const expdesc so enclosing operators can fold against it
     // without ever loading from the local's register. Plain locals (and
     // const-locals whose initializer didn't fold) return their register.
-    if let Some(data) = ctx.resolve_local(name) {
-        let kind = data.kind;
-        let register = data.register;
+    // A `global` decl in scope shadows an enclosing local/upvalue of the
+    // same name (manual.of:251-253); such a reference skips both local and
+    // upvalue resolution and falls through to global resolution below.
+    let local = ctx.resolve_local(name).map(|d| (d.kind, d.register));
+    let shadow_global = matches!(local, Some((VarKind::Global, _)));
+    if let Some((kind, register)) = local.filter(|_| !shadow_global) {
         if let VarKind::Const(Some(v)) = kind {
             return Ok(v.to_expr_desc());
         }
@@ -2506,7 +2553,7 @@ fn compile_expr_ident(
     // bypassing upvalue registration so the resulting prototype carries
     // no descriptor for it (matches Lua 5.5: const refs across function
     // boundaries don't appear in the inner function's upvalue list).
-    if let Some(resolution) = ctx.resolve_or_capture(name) {
+    if !shadow_global && let Some(resolution) = ctx.resolve_or_capture(name) {
         match resolution {
             ResolvedName::Const(v) => return Ok(v.to_expr_desc()),
             ResolvedName::Upvalue(idx) => {

--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -1,7 +1,5 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem;
-use std::rc::Rc;
 
 use cstree::interning::TokenInterner;
 
@@ -229,33 +227,55 @@ impl GlobalKind {
     }
 }
 
-/// Lua 5.5 chunk-level global declaration state. Shared by reference
-/// across every nested-function `Ctx` in the same chunk so that a
-/// `global` declaration anywhere in the chunk is visible to every
-/// function. Without this sharing, an inner function would see only
-/// its own (empty) declaration table and miss the outer's.
+/// What happens to a free name that has no explicit `global` declaration
+/// in scope. The two `*`-bearing variants are deliberately distinct: a
+/// list-form `global Name` voids the *preambular* `global *` only
+/// (`manual.of:225-228`), so a `global Name` after an explicit
+/// `global *` leaves the explicit one in force.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DefaultPolicy {
+    /// The implicit chunk preamble `global *` (read-write). Voided to
+    /// `None` by any list-form `global Name` declaration in scope.
+    Preamble,
+    /// An explicit `global *` / `global<const> *` declaration in scope.
+    /// Not voided by a later `global Name`.
+    Star(GlobalKind),
+    /// No default in scope: every free name must be declared.
+    None,
+}
+
+/// Lua 5.5 `global` declaration state. Lexically scoped exactly like a
+/// `local` (`manual.of:245-249`): a declaration's scope runs from the
+/// statement after it to the end of the innermost enclosing block. We
+/// enforce that by snapshotting this whole struct on `push_scope` and
+/// restoring it on `pop_scope`, and by handing each nested function a
+/// *clone* of the parent's current state — so outer declarations are
+/// visible inward, but an inner block's or function's declarations
+/// never leak back out to the enclosing or sibling scopes.
+#[derive(Clone)]
 struct GlobalEnv {
     /// Names introduced by an *explicit* `global Name` declaration.
     /// Reads of these emit `ERRNNIL` after `GETTABUP` (a never-assigned
     /// declared global is an error in 5.5 — `manual.of:1700`).
     decls: HashMap<String, GlobalKind>,
-    /// `true` while undeclared free names are allowed and treated as
-    /// implicit globals of `default_kind`. Starts `true` because every
-    /// chunk has an implicit `global *` (`manual.of:225-228`); set to
-    /// `false` by any `global Name(...)` declaration; re-set to `true`
-    /// by an explicit `global<attrib>? *`.
-    default_active: bool,
-    /// Default kind for the implicit / collective `*` declaration.
-    /// Initially `GlobalKind::Reg` to match the preamble's `global *`.
-    default_kind: GlobalKind,
+    /// Policy for free names with no declaration in scope.
+    default: DefaultPolicy,
 }
 
 impl GlobalEnv {
     fn new() -> Self {
         Self {
             decls: HashMap::new(),
-            default_active: true,
-            default_kind: GlobalKind::Reg,
+            default: DefaultPolicy::Preamble,
+        }
+    }
+
+    /// A list-form `global Name` declaration voids the implicit preamble
+    /// but leaves an explicit `global *` in force (`manual.of:225-228` —
+    /// only the *preambular* declaration becomes void).
+    fn void_preamble(&mut self) {
+        if self.default == DefaultPolicy::Preamble {
+            self.default = DefaultPolicy::None;
         }
     }
 }
@@ -332,9 +352,13 @@ struct Ctx<'gc, 'a> {
     /// `Chunk::upvalue_desc: Box<[UpValueDescriptor]>` at assembly time.
     upvalues: Vec<(String, UpValueDescriptor)>,
 
-    /// Lua 5.5 chunk-level global state. Shared across every nested
-    /// `Ctx` in the same chunk.
-    globals: Rc<RefCell<GlobalEnv>>,
+    /// Lua 5.5 global-declaration state, currently in scope. Owned per
+    /// function; nested functions receive a clone (see `compile_nested`).
+    globals: GlobalEnv,
+    /// `globals` snapshot saved on each `push_scope`, restored on the
+    /// matching `pop_scope` so a block-local `global` decl is scoped to
+    /// its block.
+    scope_globals: Vec<GlobalEnv>,
 }
 
 impl<'gc, 'a> Ctx<'gc, 'a> {
@@ -1067,6 +1091,7 @@ impl<'gc, 'a> Ctx<'gc, 'a> {
             nactvar: self.chunk.nactvar,
         });
         self.scope_close.push(Vec::new());
+        self.scope_globals.push(self.globals.clone());
     }
 
     fn pop_scope(&mut self) -> Result<Vec<RegisterIndex>, CompileError> {
@@ -1077,6 +1102,12 @@ impl<'gc, 'a> Ctx<'gc, 'a> {
             .ok_or_else(|| ice("missing scope register base"))?;
         self.chunk.freereg = mark.freereg;
         self.chunk.nactvar = mark.nactvar;
+        // Drop any `global` declarations made within this block — their
+        // lexical scope ends here (`manual.of:245-249`).
+        self.globals = self
+            .scope_globals
+            .pop()
+            .ok_or_else(|| ice("missing scope global mark"))?;
         self.scope_close
             .pop()
             .ok_or_else(|| ice("missing scope close list"))
@@ -1291,10 +1322,10 @@ pub fn compile<'gc>(
     root: &Root,
     interner: &TokenInterner,
 ) -> Result<Gc<'gc, Prototype<'gc>>, CompileError> {
-    // One `GlobalEnv` per chunk, threaded through nested-function
-    // compilation so a `global` declaration in any function is visible
-    // to every other function in the same chunk.
-    let globals = Rc::new(RefCell::new(GlobalEnv::new()));
+    // The chunk starts with the implicit `global *` (global-by-default);
+    // nested functions inherit a clone of whatever is in scope at their
+    // definition site (see `compile_nested`).
+    let globals = GlobalEnv::new();
     let chunk = compile_function_to_chunk(
         ctx,
         interner,
@@ -1329,7 +1360,7 @@ fn compile_function_to_chunk<'gc, 'a>(
     arity: u8,
     source: Option<LuaString<'gc>>,
     initial_upvalues: Vec<(String, UpValueDescriptor)>,
-    globals: Rc<RefCell<GlobalEnv>>,
+    globals: GlobalEnv,
 ) -> Result<Chunk<'gc>, CompileError> {
     let mut chunk = Chunk::new();
     chunk.is_vararg = is_vararg;
@@ -1348,6 +1379,7 @@ fn compile_function_to_chunk<'gc, 'a>(
         capture: parent_capture,
         upvalues: initial_upvalues,
         globals,
+        scope_globals: Vec::new(),
     };
 
     ctx.push_scope();
@@ -1747,11 +1779,8 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
         // Register first so the body can reference it as a declared
         // global. List-form declarations (this included) void the
         // implicit `global *` per `manual.of:225-228`.
-        {
-            let mut env = ctx.globals.borrow_mut();
-            env.default_active = false;
-            env.decls.insert(name.clone(), GlobalKind::Reg);
-        }
+        ctx.globals.void_preamble();
+        ctx.globals.decls.insert(name.clone(), GlobalKind::Reg);
 
         // Compile the closure into a register. `compile_func_body`
         // honours the dst hint, so `func_reg == target_reg` (asserted
@@ -1800,10 +1829,10 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
     };
 
     if item.is_star() {
-        // Form 2: `global <attrib>? *`.
-        let mut env = ctx.globals.borrow_mut();
-        env.default_active = true;
-        env.default_kind = default_kind;
+        // Form 2: `global <attrib>? *`. Establishes an explicit default
+        // for the rest of this block; unlike the preamble, a later
+        // `global Name` won't void it.
+        ctx.globals.default = DefaultPolicy::Star(default_kind);
         return Ok(());
     }
 
@@ -1819,24 +1848,23 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
     // self-referential `global X = X` resolves X as declared, not
     // implicit). Voids the implicit `global *`.
     let mut decl_kinds: Vec<(String, GlobalKind)> = Vec::with_capacity(targets.len());
-    {
-        let mut env = ctx.globals.borrow_mut();
-        env.default_active = false;
-        for target in &targets {
-            let name = target
-                .name()
-                .ok_or_else(|| ice("global target without name"))?
-                .name(ctx.interner)
-                .ok_or_else(|| ice("ident without name"))?
-                .to_owned();
-            let kind = if target.is_const() {
-                GlobalKind::Const
-            } else {
-                default_kind
-            };
-            env.decls.insert(name.clone(), kind);
-            decl_kinds.push((name, kind));
-        }
+    for target in &targets {
+        let name = target
+            .name()
+            .ok_or_else(|| ice("global target without name"))?
+            .name(ctx.interner)
+            .ok_or_else(|| ice("ident without name"))?
+            .to_owned();
+        let kind = if target.is_const() {
+            GlobalKind::Const
+        } else {
+            default_kind
+        };
+        decl_kinds.push((name, kind));
+    }
+    ctx.globals.void_preamble();
+    for (name, kind) in &decl_kinds {
+        ctx.globals.decls.insert(name.clone(), *kind);
     }
 
     if values.is_empty() {
@@ -2088,29 +2116,33 @@ fn compile_lvalue(
                 // `global *` scope is in effect; once any explicit
                 // declaration has voided it, undeclared writes are
                 // rejected.
-                let env = ctx.globals.borrow();
-                if let Some(kind) = env.decls.get(name).copied() {
+                if let Some(kind) = ctx.globals.decls.get(name).copied() {
                     if kind.is_const() {
                         return Err(err(
-                            CompileErrorKind::Internal("assignment to read-only global"),
+                            CompileErrorKind::ConstGlobalAssign(name.to_owned()),
                             LineNumber(0),
                         ));
                     }
-                } else if !env.default_active {
-                    return Err(err(
-                        CompileErrorKind::Internal("undeclared global"),
-                        LineNumber(0),
-                    ));
-                } else if env.default_kind.is_const() {
-                    // Under `global<const> *`, undeclared writes are
-                    // also rejected — the implicit declaration kind is
-                    // read-only.
-                    return Err(err(
-                        CompileErrorKind::Internal("assignment to read-only global"),
-                        LineNumber(0),
-                    ));
+                } else {
+                    match ctx.globals.default {
+                        // No default in scope: undeclared write rejected.
+                        DefaultPolicy::None => {
+                            return Err(err(
+                                CompileErrorKind::UndeclaredGlobal(name.to_owned()),
+                                LineNumber(0),
+                            ));
+                        }
+                        // Under `global<const> *` the implicit kind is
+                        // read-only, so undeclared writes are rejected too.
+                        DefaultPolicy::Star(GlobalKind::Const) => {
+                            return Err(err(
+                                CompileErrorKind::ConstGlobalAssign(name.to_owned()),
+                                LineNumber(0),
+                            ));
+                        }
+                        DefaultPolicy::Preamble | DefaultPolicy::Star(GlobalKind::Reg) => {}
+                    }
                 }
-                drop(env);
                 let (key, ic_idx) = ctx.alloc_field_key(name.as_bytes())?;
                 let env_idx = ctx
                     .resolve_env_upvalue()
@@ -2366,7 +2398,10 @@ fn compile_nested<'gc>(
 ) -> Result<Gc<'gc, Prototype<'gc>>, CompileError> {
     let lua_ctx = ctx.ctx;
     let interner = ctx.interner;
-    let globals = Rc::clone(&ctx.globals);
+    // The child inherits the declarations in scope at its definition site,
+    // but mutates its own copy — its `global` decls don't leak back to the
+    // parent or to sibling functions (`manual.of:245-249`).
+    let globals = ctx.globals.clone();
     let parent: &mut dyn UpvalueResolver = ctx;
 
     let chunk = compile_function_to_chunk(
@@ -2488,15 +2523,13 @@ fn compile_expr_ident(
     // undeclared free names are rejected. Reads of declared globals
     // do *not* emit a runtime `ERRNNIL` — that opcode guards
     // initialization (see `compile_global`), not plain reads.
-    let globals = ctx.globals.borrow();
-    let declared = globals.decls.contains_key(name);
-    if !declared && !globals.default_active {
+    let declared = ctx.globals.decls.contains_key(name);
+    if !declared && ctx.globals.default == DefaultPolicy::None {
         return Err(err(
-            CompileErrorKind::Internal("undeclared global"),
+            CompileErrorKind::UndeclaredGlobal(name.to_owned()),
             LineNumber(0),
         ));
     }
-    drop(globals);
 
     let (key, ic_idx) = ctx.alloc_field_key(name.as_bytes())?;
     let dst = ctx.dst_or_alloc(dst)?;

--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -1894,12 +1894,21 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
     if has_values {
         for (i, expr) in values.into_iter().enumerate() {
             let want = RegisterIndex(value_base + i as u8);
-            let got = compile_expr_to_reg(ctx, expr, Some(want))?;
+            let got = compile_expr_to_reg(ctx, expr, None)?;
             if got != want {
+                // Bare local/upvalue (or a mid-stack short-circuit result):
+                // reclaim any leaked temps, reserve the value slot so the
+                // nil-pad loop below can't overwrite it, then MOVE down.
+                ctx.chunk.freereg = want.0;
+                let slot = ctx.reserve_reg()?;
+                debug_assert_eq!(slot.0, want.0);
                 ctx.emit(Instruction::MOVE {
                     dst: want.0,
                     src: got.0,
                 });
+            } else if ctx.chunk.freereg > want.0 + 1 {
+                // Landed at `want` but leaked temps above; drop them.
+                ctx.chunk.freereg = want.0 + 1;
             }
         }
         // Pad with nil for any names beyond the supplied values.

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -128,11 +128,11 @@ test_err!(
     for_counter_readonly_err,
     "test-files/for_counter_readonly_err.lua"
 );
-test!(
+test_err!(
     global_nested_propagation,
     "test-files/global_nested_propagation.lua"
 );
-test!(global_star_nested, "test-files/global_star_nested.lua");
+test_err!(global_star_nested, "test-files/global_star_nested.lua");
 test!(global_const_star, "test-files/global_const_star.lua");
 test!(const_fold, "test-files/const_fold.lua");
 test!(const_no_fold, "test-files/const_no_fold.lua");

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -134,6 +134,8 @@ test_err!(
 );
 test_err!(global_star_nested, "test-files/global_star_nested.lua");
 test!(global_const_star, "test-files/global_const_star.lua");
+test!(global_shadows_local, "test-files/global_shadows_local.lua");
+test_err!(global_self_init_err, "test-files/global_self_init_err.lua");
 test!(const_fold, "test-files/const_fold.lua");
 test!(const_no_fold, "test-files/const_no_fold.lua");
 test!(const_fold_branch, "test-files/const_fold_branch.lua");

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -136,6 +136,7 @@ test_err!(global_star_nested, "test-files/global_star_nested.lua");
 test!(global_const_star, "test-files/global_const_star.lua");
 test!(global_shadows_local, "test-files/global_shadows_local.lua");
 test_err!(global_self_init_err, "test-files/global_self_init_err.lua");
+test!(global_init_shadow, "test-files/global_init_shadow.lua");
 test!(const_fold, "test-files/const_fold.lua");
 test!(const_no_fold, "test-files/const_no_fold.lua");
 test!(const_fold_branch, "test-files/const_fold_branch.lua");

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_const_assign_err.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_const_assign_err.snap
@@ -2,4 +2,4 @@
 source: src/compiler/snapshot_tests.rs
 expression: output
 ---
-compiler error at line 1: internal compiler error: assignment to read-only global
+compiler error at line 1: attempt to assign to const variable 'X'

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_init_shadow.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_init_shadow.snap
@@ -1,0 +1,38 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=5, upvalues=1)
+; constants:
+;   K0 = "P"
+;   K1 = "Q"
+;   K2 = "p"
+;   K3 = "q"
+;   K4 = "print"
+;   K5 = "a"
+;   K6 = "b"
+;   K7 = "A"
+;   K8 = "B"
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  LOAD            R0 K0  ; "P"
+0002  LOAD            R1 K1  ; "Q"
+0003  MOVE            R2 R0
+0004  MOVE            R3 R1
+0005  GETTABUP        R4 U0 K2  ; "p"
+0006  ERRNNIL         R4 name=K2
+0007  SETTABUP        R2 U0 K2  ; "p"
+0008  GETTABUP        R4 U0 K3  ; "q"
+0009  ERRNNIL         R4 name=K3
+0010  SETTABUP        R3 U0 K3  ; "q"
+0011  GETTABUP        R2 U0 K4  ; "print"
+0012  GETTABUP        R3 U0 K2  ; "p"
+0013  GETTABUP        R4 U0 K3  ; "q"
+0014  CALL            R2 args=3 ret=1
+0015  LOAD            R2 K7  ; "A"
+0016  LOAD            R3 K8  ; "B"
+0017  SETTABUP        R2 U0 K5  ; "a"
+0018  SETTABUP        R3 U0 K6  ; "b"
+0019  RETURN          R0 count=1

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_nested_propagation.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_nested_propagation.snap
@@ -1,26 +1,5 @@
 ---
 source: src/compiler/snapshot_tests.rs
-assertion_line: 128
 expression: output
 ---
-; function (params=0, vararg=true, stack=3, upvalues=1)
-; constants:
-;   K0 = "Y"
-;   K1 = 1
-;   K2 = "print"
-; upvalues:
-;   U0 = local R0
-; code:
-0000  VARARGPREP      fixed=0
-0001  CLOSURE         R0 P0
-0002  LOAD            R1 K1  ; 1
-0003  SETTABUP        R1 U0 K0  ; "Y"
-0004  GETTABUP        R1 U0 K2  ; "print"
-0005  GETTABUP        R2 U0 K0  ; "Y"
-0006  CALL            R1 args=2 ret=1
-0007  RETURN          R0 count=1
-
-; prototype 0:
-  ; function (params=0, vararg=false, stack=0, upvalues=0)
-  ; code:
-  0000  RETURN          R0 count=1
+compiler error at line 1: variable 'Y' not declared

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_self_init_err.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_self_init_err.snap
@@ -1,0 +1,5 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+compiler error at line 1: variable 'x' not declared

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_shadows_local.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_shadows_local.snap
@@ -1,0 +1,21 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=3, upvalues=1)
+; constants:
+;   K0 = 1
+;   K1 = "v"
+;   K2 = 2
+;   K3 = "print"
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  LOAD            R0 K0  ; 1
+0002  LOAD            R1 K2  ; 2
+0003  SETTABUP        R1 U0 K1  ; "v"
+0004  GETTABUP        R1 U0 K3  ; "print"
+0005  MOVE            R2 R0
+0006  CALL            R1 args=2 ret=1
+0007  RETURN          R0 count=1

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_star_nested.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_star_nested.snap
@@ -2,20 +2,4 @@
 source: src/compiler/snapshot_tests.rs
 expression: output
 ---
-; function (params=0, vararg=true, stack=2, upvalues=1)
-; constants:
-;   K0 = "A"
-;   K1 = 1
-; upvalues:
-;   U0 = local R0
-; code:
-0000  VARARGPREP      fixed=0
-0001  CLOSURE         R0 P0
-0002  LOAD            R1 K1  ; 1
-0003  SETTABUP        R1 U0 K0  ; "A"
-0004  RETURN          R0 count=1
-
-; prototype 0:
-  ; function (params=0, vararg=false, stack=0, upvalues=0)
-  ; code:
-  0000  RETURN          R0 count=1
+compiler error at line 1: variable 'A' not declared

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_undeclared_err.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_undeclared_err.snap
@@ -2,4 +2,4 @@
 source: src/compiler/snapshot_tests.rs
 expression: output
 ---
-compiler error at line 1: internal compiler error: undeclared global
+compiler error at line 1: variable 'Z' not declared

--- a/test-files/global_init_shadow.lua
+++ b/test-files/global_init_shadow.lua
@@ -1,0 +1,5 @@
+global print, a, b
+local p, q = "P", "Q"
+global p, q = p, q
+print(p, q)
+a, b = "A", "B"

--- a/test-files/global_self_init_err.lua
+++ b/test-files/global_self_init_err.lua
@@ -1,0 +1,2 @@
+global print
+global x = x

--- a/test-files/global_shadows_local.lua
+++ b/test-files/global_shadows_local.lua
@@ -1,0 +1,7 @@
+global print
+local v = 1
+do
+  global v
+  v = 2
+end
+print(v)


### PR DESCRIPTION
## Summary

Enforces Lua 5.5's lexical scoping for `global` declarations, which tcvm previously ignored — it kept one chunk-wide, never-restored declaration table, so a `global` declared in a nested function or a block leaked to enclosing/sibling scopes and the voiding of global-by-default never rolled back. Two test files had baked the wrong-accept into their snapshots.

Closes #78.

## What changed

**1. Lexical scoping + diagnostics** (`compiler: lexically scope Lua 5.5 global declarations`)
- `GlobalEnv` is now owned per function. Nested functions receive a *clone* of the parent's in-scope state — outer declarations stay visible inward, inner declarations don't leak back out.
- `push_scope`/`pop_scope` snapshot and restore it onto a `scope_globals` stack, so a block-local `global` decl is confined to its block.
- The `default_active` bool becomes a 3-state `DefaultPolicy { Preamble, Star(kind), None }`: a list-form `global Name` voids only the implicit preamble `global *`, not an explicit one (`manual.of:225-228`).
- New `CompileErrorKind::UndeclaredGlobal` / `ConstGlobalAssign` with Lua-exact messages, replacing the `Internal(...)` misclassification that surfaced user errors as internal compiler errors. The CLI prints a clean diagnostic and exits 1 instead of panicking via `.unwrap()`.

**2. Declaration shadowing + initializer scope** (`compiler: make global declarations shadow locals and scope their initializers`)
- A `global X` now shadows an in-scope `local`/upvalue of the same name with correct lexical recency (`manual.of:251-253`), via a `VarKind::Global` marker in the lexical scope stack that falls through to `_ENV` resolution. Works across function boundaries.
- `global X = expr` compiles its initializer *before* the declaration takes effect — a declaration's scope begins at the next statement (`manual.of:245-248`) — so the RHS sees the outer/undeclared name.

**3. Initializer codegen fix** (`compiler: fix global-initializer value clobbered by nil-pad loop`)
- `global a, b = <bare local/upvalue>` MOVE'd the value into its slot without advancing `freereg`, so the nil-pad loop overwrote it (stored nil). Now mirrors the `local a, b = …` freereg discipline. The shadow marker had made this pre-existing clobber observable for `global x = x`.

## Verification

- Matches Lua 5.5.0 (verdict + stdout + error wording) across ~50 differential cases: all block types (`do`/`if`/`while`/`for`/`repeat`), cross-function and re-shadowing, explicit-vs-implicit `*`, const interactions, initializer and `global function` forms.
- Full test suite green; `cargo clippy` clean. Adds 4 regression test files + snapshots; the two test files that had baked in the wrong behavior move from `test!` to `test_err!`.

## Out of scope

A separate, pre-existing limitation remains: a multi-value RHS in a `global` initializer (`global a, b = f()`) only captures the first value. Not addressed here.
