### PR TITLE
parser: handle integer literals that overflow i64

### DIFF
--- a/src/parser/lit.rs
+++ b/src/parser/lit.rs
@@ -6,12 +6,21 @@ pub fn parse_int(s: &str) -> Result<i64, ParseIntError> {
     s.parse()
 }
 
-pub fn parse_hex_int(s: &str) -> Result<i64, ParseIntError> {
+// Hex integer literals wrap mod 2^64 per Lua 5.5 lexical conventions, so fold
+// digit-by-digit ignoring overflow (matching `luaO_hexavalue`) rather than
+// `from_str_radix`, which would reject >16 digits instead of keeping the low 64.
+pub fn parse_hex_int(s: &str) -> i64 {
     let s = s
         .strip_prefix("0x")
         .or_else(|| s.strip_prefix("0X"))
         .unwrap_or(s);
-    i64::from_str_radix(s, 16)
+    let mut acc: u64 = 0;
+    for ch in s.chars() {
+        // The HexInt lexer regex guarantees every digit is valid hex.
+        let digit = ch.to_digit(16).expect("hex literal has only hex digits");
+        acc = acc.wrapping_mul(16).wrapping_add(digit as u64);
+    }
+    acc as i64
 }
 
 pub fn parse_float(s: &str) -> Result<f64, ParseFloatError> {
@@ -206,10 +215,34 @@ fn utf8_encode(dst: &mut Vec<u8>, cp: u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_string;
+    use super::{parse_hex_int, parse_int, parse_string};
 
     fn parse(s: &str) -> Vec<u8> {
         super::parse_string(s).expect("well-formed literal")
+    }
+
+    // Hex int literals wrap mod 2^64; >16 digits keep the low 64 bits.
+    // Values cross-checked against lua 5.5.0.
+    #[test]
+    fn hex_int_wraps_mod_2_64() {
+        assert_eq!(parse_hex_int("0xff"), 255);
+        assert_eq!(parse_hex_int("0x7fffffffffffffff"), i64::MAX);
+        assert_eq!(parse_hex_int("0x8000000000000000"), i64::MIN);
+        assert_eq!(parse_hex_int("0xffffffffffffffff"), -1);
+        assert_eq!(parse_hex_int("0x10000000000000000"), 0); // 2^64 -> 0
+        assert_eq!(parse_hex_int("0xffffffffffffffffff"), -1); // >16 digits
+    }
+
+    // A decimal int at the i64 boundary stays integer; one past it overflows
+    // (the caller then reparses it as a float).
+    #[test]
+    fn decimal_int_boundary_and_overflow() {
+        assert_eq!(parse_int("9223372036854775807"), Ok(i64::MAX));
+        assert!(parse_int("9223372036854775808").is_err());
+        assert_eq!(
+            super::parse_float("9223372036854775808"),
+            Ok(9223372036854775808.0)
+        );
     }
 
     // `parse_string` expects the surrounding quotes; the raw strings below are

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -91,6 +91,7 @@ mod tests {
     test!(literal, "test-files/literal.lua");
     test!(hex_numeral, "test-files/hex_numeral.lua");
     test!(decimal_numeral, "test-files/decimal_numeral.lua");
+    test!(int_overflow_numeral, "test-files/int_overflow_numeral.lua");
     test!(nbody, "test-files/nbody.lua");
     test!(op_prec, "test-files/op_prec.lua");
     test!(primes, "test-files/primes.lua");

--- a/src/parser/snapshots/tcvm__parser__tests__parse_int_overflow_numeral.snap
+++ b/src/parser/snapshots/tcvm__parser__tests__parse_int_overflow_numeral.snap
@@ -1,0 +1,109 @@
+---
+source: src/parser/mod.rs
+expression: syntax_tree
+---
+Root@0..212
+  AssignStmt@0..21
+    AssignList@0..1
+      Ident@0..1
+        Ident@0..1 "a"
+    Assign@1..2 "="
+    ExprList@2..21
+      LiteralExpr@2..21
+        Int@2..21 "9223372036854775808"
+  AssignStmt@21..46
+    AssignList@21..22
+      Ident@21..22
+        Ident@21..22 "b"
+    Assign@22..23 "="
+    ExprList@23..46
+      LiteralExpr@23..46
+        Int@23..46 "99999999999999999999999"
+  AssignStmt@46..68
+    AssignList@46..47
+      Ident@46..47
+        Ident@46..47 "c"
+    Assign@47..48 "="
+    ExprList@48..68
+      LiteralExpr@48..68
+        Int@48..68 "18446744073709551616"
+  AssignStmt@68..89
+    AssignList@68..69
+      Ident@68..69
+        Ident@68..69 "d"
+    Assign@69..70 "="
+    ExprList@70..89
+      LiteralExpr@70..89
+        Int@70..89 "9223372036854775807"
+  AssignStmt@89..109
+    AssignList@89..90
+      Ident@89..90
+        Ident@89..90 "e"
+    Assign@90..91 "="
+    ExprList@91..109
+      LiteralExpr@91..109
+        HexInt@91..109 "0x7fffffffffffffff"
+  AssignStmt@109..129
+    AssignList@109..110
+      Ident@109..110
+        Ident@109..110 "f"
+    Assign@110..111 "="
+    ExprList@111..129
+      LiteralExpr@111..129
+        HexInt@111..129 "0x8000000000000000"
+  AssignStmt@129..149
+    AssignList@129..130
+      Ident@129..130
+        Ident@129..130 "g"
+    Assign@130..131 "="
+    ExprList@131..149
+      LiteralExpr@131..149
+        HexInt@131..149 "0xffffffffffffffff"
+  AssignStmt@149..170
+    AssignList@149..150
+      Ident@149..150
+        Ident@149..150 "h"
+    Assign@150..151 "="
+    ExprList@151..170
+      LiteralExpr@151..170
+        HexInt@151..170 "0x10000000000000000"
+  AssignStmt@170..192
+    AssignList@170..171
+      Ident@170..171
+        Ident@170..171 "i"
+    Assign@171..172 "="
+    ExprList@172..192
+      LiteralExpr@172..192
+        HexInt@172..192 "0xffffffffffffffffff"
+  AssignStmt@192..195
+    AssignList@192..193
+      Ident@192..193
+        Ident@192..193 "j"
+    Assign@193..194 "="
+    ExprList@194..195
+      LiteralExpr@194..195
+        Int@194..195 "0"
+  AssignStmt@195..199
+    AssignList@195..196
+      Ident@195..196
+        Ident@195..196 "k"
+    Assign@196..197 "="
+    ExprList@197..199
+      LiteralExpr@197..199
+        Int@197..199 "42"
+  AssignStmt@199..205
+    AssignList@199..200
+      Ident@199..200
+        Ident@199..200 "l"
+    Assign@200..201 "="
+    ExprList@201..205
+      LiteralExpr@201..205
+        HexInt@201..205 "0xff"
+  AssignStmt@205..212
+    AssignList@205..206
+      Ident@205..206
+        Ident@205..206 "m"
+    Assign@206..207 "="
+    ExprList@207..212
+      LiteralExpr@207..212
+        HexFloat@207..212 "0x1p4"

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -286,8 +286,13 @@ impl Literal {
             T![nil] => LiteralValue::Nil,
             T![true] => LiteralValue::Bool(true),
             T![false] => LiteralValue::Bool(false),
-            T![int] => LiteralValue::Int(lit::parse_int(s).ok()?),
-            T![hex_int] => LiteralValue::Int(lit::parse_hex_int(s).ok()?),
+            // A decimal integer literal that overflows i64 reparses as a float
+            // (Lua's str2int-then-str2num fall-through); hex wraps mod 2^64.
+            T![int] => match lit::parse_int(s) {
+                Ok(n) => LiteralValue::Int(n),
+                Err(_) => LiteralValue::Float(lit::parse_float(s).ok()?),
+            },
+            T![hex_int] => LiteralValue::Int(lit::parse_hex_int(s)),
             T![float] => LiteralValue::Float(lit::parse_float(s).ok()?),
             T![hex_float] => LiteralValue::Float(lit::parse_hex_float(s)?),
             T![string] => LiteralValue::String(lit::parse_string(s)?),

--- a/test-files/int_overflow_numeral.lua
+++ b/test-files/int_overflow_numeral.lua
@@ -1,0 +1,19 @@
+-- Integer literals at and beyond the i64 range (issue #109). Each previously
+-- failed to load with 'internal compiler error: literal without value'.
+-- Decimal overflow: reparsed as a float (Lua's str2int -> str2num fall-through).
+a = 9223372036854775808           -- 2^63: float
+b = 99999999999999999999999       -- float (1e+23)
+c = 18446744073709551616          -- 2^64: float
+-- The i64 boundary stays an integer.
+d = 9223372036854775807           -- i64::MAX
+-- Hex integer literals wrap mod 2^64 (read unsigned, reinterpreted as i64).
+e = 0x7fffffffffffffff            -- i64::MAX
+f = 0x8000000000000000            -- wraps to i64::MIN
+g = 0xffffffffffffffff            -- wraps to -1
+h = 0x10000000000000000           -- 2^64 -> 0
+i = 0xffffffffffffffffff          -- >16 digits, low 64 bits -> -1
+-- Regression guards: small/normal literals and hex floats are unaffected.
+j = 0
+k = 42
+l = 0xff
+m = 0x1p4


### PR DESCRIPTION
## Summary

Integer literals whose value does not fit in `i64` were rejected at chunk-load time, so any chunk containing one failed to load with `internal compiler error: literal without value`. Lua 5.5 never errors on an out-of-range integer literal; this aligns tcvm with Lua's lexical conventions: an overflowing **decimal** integer literal promotes to a **float**, and an overflowing **hexadecimal** integer literal **wraps modulo 2^64**.

## Root cause

In `src/parser/syntax.rs`, `Literal::value` parsed integer literals with:

```rust
T![int]     => LiteralValue::Int(lit::parse_int(s).ok()?),
T![hex_int] => LiteralValue::Int(lit::parse_hex_int(s).ok()?),
```

The `.ok()?` turned an `i64` overflow into `None`, which the compiler surfaced as `internal compiler error: literal without value`. The lexer already tokenizes arbitrarily long literals (`[0-9]+` and `0[xX][0-9a-fA-F]+` in `src/parser/kind.rs`), so the failure was purely at value conversion.

## Fix

- **Decimal** (`src/parser/syntax.rs`): the `T![int]` arm now falls back to `parse_float` when `parse_int` overflows, mirroring Lua's `luaO_str2int` failure falling through to `luaO_str2num`. So an overflowing decimal literal becomes a float.
- **Hex** (`src/parser/lit.rs`): `parse_hex_int` is now infallible, folding hex digits with `wrapping_mul(16)`/`wrapping_add(digit)` over all digits — matching Lua's `luaO_hexavalue` — then casting `u64 as i64`. This wraps mod 2^64 and also handles **more than 16 hex digits** (keeping the low 64 bits), which `u64::from_str_radix` would have rejected. The `T![hex_int]` arm drops `.ok()?` accordingly.

`-9223372036854775808` needs no special case: it is unary minus applied to the float-promoted literal `9223372036854775808` (the minimum integer is not writable as a decimal literal in Lua). `parse_float`/`parse_hex_float` are untouched.

## Verification

Reference: `lua` 5.5.0 (`/opt/homebrew/bin/lua`).

**Primary repro** — `diff <(lua repro.lua) <(tcvm -f repro.lua)` is empty:

```
9223372036854775807
9.2233720368547758e+18
1e+23
-9.2233720368547758e+18
9223372036854775807
-9223372036854775808
-1
integer	float
integer	integer
```

**Edge cases** — `diff` empty against `lua`:

```
0x10000000000000000   -> 0                       integer   (2^64 wraps to 0)
0xffffffffffffffffff  -> -1                      integer   (>16 hex digits, low 64 bits)
18446744073709551616  -> 1.8446744073709552e+19  float     (2^64 decimal -> float)
0x1p4                 -> 16.0                     float     (hex float unaffected)
0, 42, 0xff           -> 0/42/255               integer   (small literals unaffected)
```

`math.type` tags match Lua in every case (integer vs float).

**Build / lint / format / tests:**
- `cargo build -p tcvm-cli` — clean
- `cargo fmt --all --check` — clean
- `cargo test --workspace` — all green (161 in the main lib suite plus all integration/doctest suites)
- `cargo clippy --workspace --all-targets` — no new findings from this change (the only error is a pre-existing `approx_constant` deny at `src/lua/mod.rs:505`, present on `main` and untouched here)

## Tests

- `src/parser/lit.rs`: `hex_int_wraps_mod_2_64` (incl. 16-digit and >16-digit wrap cases) and `decimal_int_boundary_and_overflow`.
- `test-files/int_overflow_numeral.lua` fixture, registered in `src/parser/mod.rs` with an accepted insta syntax-tree snapshot.

Closes #109
