### PR TITLE
coroutine: an errored coroutine becomes 'dead', not 'normal'

### DIFF
--- a/src/builtin/coroutine.rs
+++ b/src/builtin/coroutine.rs
@@ -225,7 +225,13 @@ fn lua_close<'gc>(
             ts.pending_action = None;
             ts.yield_bottom = None;
             ts.status = ThreadStatus::Stopped;
-            stack.replace(&[Value::boolean(true)]);
+            // A coroutine that died via error re-surfaces that error as
+            // `(false, err)` (and only once — clear it so a second close is
+            // `true`, matching Lua). Otherwise close succeeds with `true`.
+            match ts.death_error.take() {
+                Some(err) => stack.replace(&[Value::boolean(false), err]),
+                None => stack.replace(&[Value::boolean(true)]),
+            }
             Ok(CallbackAction::Return)
         }
         ThreadStatus::Normal => {
@@ -249,6 +255,13 @@ fn wrap_callback<'gc>(
     let co = nctx.upvalues[0]
         .get_thread()
         .expect("wrap_callback upvalue 0 must be a thread");
+    // Gate the resume like `lua_resume` does; without this, resuming a dead
+    // (or otherwise non-suspended) thread reaches `schedule_thread_resume`
+    // and aborts the whole executor with `BadMode`. `wrap` re-raises errors
+    // rather than wrapping them, so we throw the reason directly.
+    if let Some(msg) = unresumable_reason(co, &nctx) {
+        return Err(Error::from_str(nctx.ctx, msg));
+    }
     let then = BoxSequence::new(nctx.ctx.mutation(), UnwrapResumeSequence);
     Ok(CallbackAction::Resume {
         thread: co,

--- a/src/env/thread.rs
+++ b/src/env/thread.rs
@@ -141,6 +141,11 @@ pub struct ThreadState<'gc> {
     /// state.
     #[collect(require_static)]
     pub yield_bottom: Option<CallSite>,
+    /// The error value that killed this coroutine, set when an uncaught error
+    /// unwinds out of it (status -> `Stopped`). `coroutine.close` surfaces it
+    /// as `(false, err)` and clears it; `None` for a coroutine that died by
+    /// normal return or was never run.
+    pub death_error: Option<Value<'gc>>,
 }
 
 /// A native callback wants to suspend / call / yield / resume; the executor
@@ -224,6 +229,7 @@ impl<'gc> Thread<'gc> {
             thread_handle: None,
             pending_action: None,
             yield_bottom: None,
+            death_error: None,
         };
         let thread = Thread(Gc::new(mc, RefLock::new(state)));
         // Store the back-reference

--- a/src/lua/executor.rs
+++ b/src/lua/executor.rs
@@ -969,6 +969,16 @@ fn unwind_error<'gc>(
     // the resumer's WaitThread → its next Sequence can catch.
     let stack_len = exec.0.borrow().thread_stack.len();
     if stack_len > 1 {
+        // Error terminates this coroutine: no result values, so `Stopped`
+        // (not `Result`) is its terminal/dead marker. Every coroutine the
+        // error unwinds through re-enters here on a later pump and is marked
+        // dead too, matching Lua's "kill the whole unwound chain". Stash the
+        // killing error so `coroutine.close` can surface it as `(false, err)`.
+        {
+            let mut ts = top.borrow_mut(mc);
+            ts.status = ThreadStatus::Stopped;
+            ts.death_error = Some(err.value());
+        }
         exec.0.borrow_mut(mc).thread_stack.pop();
         let resumer = *exec.0.borrow().thread_stack.last().unwrap();
         let mut rs = resumer.borrow_mut(mc);

--- a/tests/coroutine_error.rs
+++ b/tests/coroutine_error.rs
@@ -39,3 +39,135 @@ fn native_error_inside_coroutine() {
     let result: i64 = lua.execute(&ex).expect("run");
     assert_eq!(result, 1, "ok=false and msg=='boom'");
 }
+
+/// An errored coroutine transitions to 'dead' (issue #86): status is 'dead'
+/// and a second resume reports 'cannot resume dead coroutine'. Also locks in
+/// the no-regression cases: a normally-returned coroutine is 'dead' and a
+/// yielded one is 'suspended'.
+#[test]
+fn errored_coroutine_is_dead() {
+    let mut lua = Lua::new();
+    lua.load_all();
+
+    let ex = lua
+        .try_enter(|ctx| -> Result<_, LoadError> {
+            let chunk = ctx.load(
+                "local co = coroutine.create(function() error('x') end)\n\
+                 coroutine.resume(co)\n\
+                 if coroutine.status(co) ~= 'dead' then return 10 end\n\
+                 local ok2, e2 = coroutine.resume(co)\n\
+                 if ok2 ~= false then return 11 end\n\
+                 if e2 ~= 'cannot resume dead coroutine' then return 12 end\n\
+                 local done = coroutine.create(function() return 1 end)\n\
+                 coroutine.resume(done)\n\
+                 if coroutine.status(done) ~= 'dead' then return 13 end\n\
+                 local yld = coroutine.create(function() coroutine.yield() end)\n\
+                 coroutine.resume(yld)\n\
+                 if coroutine.status(yld) ~= 'suspended' then return 14 end\n\
+                 return 1",
+                Some("errored_coroutine_is_dead"),
+            )?;
+            Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+        })
+        .expect("load");
+    let result: i64 = lua.execute(&ex).expect("run");
+    assert_eq!(
+        result, 1,
+        "errored coroutine dead + 2nd-resume msg + no-regress"
+    );
+}
+
+/// A multi-level unwind (outer resumes a wrapped inner that errors; the
+/// re-raise unwinds outer with no catcher) kills the outer coroutine too.
+#[test]
+fn nested_error_kills_outer_coroutine() {
+    let mut lua = Lua::new();
+    lua.load_all();
+
+    let ex = lua
+        .try_enter(|ctx| -> Result<_, LoadError> {
+            let chunk = ctx.load(
+                "local outer = coroutine.create(function()\n\
+                 \x20 local w = coroutine.wrap(function() error('inner') end)\n\
+                 \x20 w()\n\
+                 end)\n\
+                 local ok = coroutine.resume(outer)\n\
+                 if ok ~= false then return 20 end\n\
+                 if coroutine.status(outer) ~= 'dead' then return 21 end\n\
+                 return 1",
+                Some("nested_error_kills_outer_coroutine"),
+            )?;
+            Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+        })
+        .expect("load");
+    let result: i64 = lua.execute(&ex).expect("run");
+    assert_eq!(
+        result, 1,
+        "outer coroutine is 'dead' after inner error unwinds it"
+    );
+}
+
+/// `coroutine.close` on a coroutine that died via error re-surfaces the
+/// killing error as `(false, err)` (and only once — a second close is
+/// `true`). A normally-completed coroutine still closes with `true`.
+#[test]
+fn close_error_dead_returns_false_and_error() {
+    let mut lua = Lua::new();
+    lua.load_all();
+
+    let ex = lua
+        .try_enter(|ctx| -> Result<_, LoadError> {
+            let chunk = ctx.load(
+                "local c = coroutine.create(function() error('x') end)\n\
+                 coroutine.resume(c)\n\
+                 local ok, e = coroutine.close(c)\n\
+                 if ok ~= false then return 30 end\n\
+                 if e ~= 'x' then return 31 end\n\
+                 if coroutine.close(c) ~= true then return 32 end\n\
+                 local d = coroutine.create(function() return 1 end)\n\
+                 coroutine.resume(d)\n\
+                 if coroutine.close(d) ~= true then return 33 end\n\
+                 local t = coroutine.create(function() error({code=7}) end)\n\
+                 coroutine.resume(t)\n\
+                 local ok2, v = coroutine.close(t)\n\
+                 if ok2 ~= false then return 34 end\n\
+                 if type(v) ~= 'table' or v.code ~= 7 then return 35 end\n\
+                 return 1",
+                Some("close_error_dead_returns_false_and_error"),
+            )?;
+            Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+        })
+        .expect("load");
+    let result: i64 = lua.execute(&ex).expect("run");
+    assert_eq!(result, 1, "close surfaces death error as (false, err)");
+}
+
+/// Re-invoking a `coroutine.wrap` closure after its body errored re-raises
+/// 'cannot resume dead coroutine' (gated like `resume`) instead of aborting
+/// the executor. The error is observed via a guard coroutine so `resume`
+/// catches it.
+#[test]
+fn wrap_recall_after_error_reports_dead() {
+    let mut lua = Lua::new();
+    lua.load_all();
+
+    let ex = lua
+        .try_enter(|ctx| -> Result<_, LoadError> {
+            let chunk = ctx.load(
+                "local w = coroutine.wrap(function() error('boom') end)\n\
+                 local g1 = coroutine.create(w)\n\
+                 local ok1 = coroutine.resume(g1)\n\
+                 if ok1 ~= false then return 40 end\n\
+                 local g2 = coroutine.create(w)\n\
+                 local ok2, e2 = coroutine.resume(g2)\n\
+                 if ok2 ~= false then return 41 end\n\
+                 if e2 ~= 'cannot resume dead coroutine' then return 42 end\n\
+                 return 1",
+                Some("wrap_recall_after_error_reports_dead"),
+            )?;
+            Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+        })
+        .expect("load");
+    let result: i64 = lua.execute(&ex).expect("run");
+    assert_eq!(result, 1, "wrap re-call after error reports dead");
+}


### PR DESCRIPTION
## Summary

Fixes issue #86: when a coroutine body raised an uncaught error, tcvm left the coroutine in `'normal'` status instead of `'dead'`. `coroutine.status` reported the wrong value and a subsequent resume returned the wrong message (`cannot resume non-suspended coroutine` instead of Lua's `cannot resume dead coroutine`). Normal completion already became `'dead'` — only the error path was broken.

## Root cause

The abnormal-termination path in `unwind_error` (`src/lua/executor.rs`) propagated the error to the resumer but never moved the errored thread to a terminal state, leaving it `ThreadStatus::Normal`. The status/resume mappings in `src/builtin/coroutine.rs` (`coroutine.status`, `unresumable_reason`) were already correct *given* the status — they just received the wrong one.

## Fix

- `src/lua/executor.rs` — in `unwind_error`, when an uncaught error unwinds out of a resumed coroutine, set its status to `ThreadStatus::Stopped` (an error has no result values, so `Stopped`, not `Result`, is the terminal/dead marker) and stash the killing error before propagating to the resumer. Each coroutine the error unwinds through re-enters `unwind_error` on a later pump and is marked dead too — matching Lua's behavior of killing the entire unwound chain; a catch boundary stops the chain-kill.
- `src/env/thread.rs` — new `death_error: Option<Value<'gc>>` field on `ThreadState` (GC-traced) holding the error that killed the coroutine.
- `src/builtin/coroutine.rs` — `coroutine.close` consumes and clears `death_error`, returning `(false, err)` for an error-dead coroutine (only once; a second close is `true`), matching Lua across all close states. `wrap_callback` now gates its resume on `unresumable_reason` like `lua_resume`, so re-calling a `wrap` closure after its body errored re-raises `cannot resume dead coroutine` instead of aborting the executor.

## Verification (real Lua 5.5.0 vs tcvm)

Primary repro:
```
lua : resume1 false <file>:1: x | status dead | resume2 false cannot resume dead coroutine | good-status dead
tcvm: resume1 false x           | status dead | resume2 false cannot resume dead coroutine | good-status dead
```
All in-scope anchors match: errored coroutine is `dead`, second resume is `false cannot resume dead coroutine`, normally-returned coroutine is `dead`, a yielded one is `suspended`.

`coroutine.close` across death states (tcvm == lua): error-dead => `(false, err)`; close-again => `true`; normal => `true`; suspended => `true`; fresh => `true`; non-string (table) error value preserved => `(false, table, 42)`.

Nested error: inner error unwinding through outer (no catcher) => outer `dead`; when the inner error is caught by `coroutine.resume` inside outer, only inner dies and outer completes normally — both match lua.

Wrap re-call after error => `cannot resume dead coroutine` (no executor abort); yielding wrap across calls and re-call after normal completion both unchanged. GC-stress (200 error-dead coroutines through `collectgarbage()`) confirms `death_error` is properly traced.

Gate: `cargo build` clean, `cargo fmt --all --check` clean, `cargo clippy --workspace` 0 errors, `cargo test --workspace` 243 passed / 0 failed. (The one `clippy --all-targets` error — `approx_constant` on `3.14` in `src/lua/mod.rs:505` test code — is pre-existing on main and unrelated.)

## Tests

Adds to `tests/coroutine_error.rs`: `errored_coroutine_is_dead` (dead transition + second-resume message + no-regression for normal/yielded), `nested_error_kills_outer_coroutine`, `close_error_dead_returns_false_and_error` (incl. non-string error value), `wrap_recall_after_error_reports_dead`.

## Out of scope (pre-existing)

`error('str')` does not prepend Lua's `<file>:<line>: ` source-position prefix; this appears identically in plain `coroutine.resume(error(...))` and is orthogonal to coroutine status/close/wrap. `pcall` is a stub (`src/builtin/basic.rs:216`); close/wrap were verified pcall-free.

Closes #86
