### PR TITLE
compiler: expand trailing multi-return RHS in `global` declarations

### DIFF
--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -1765,6 +1765,16 @@ fn compile_decl(ctx: &mut Ctx, item: Decl) -> Result<(), CompileError> {
 // Lua 5.5 global declarations
 // ---------------------------------------------------------------------------
 
+/// Number of values a trailing multires RHS should expand to, validated for
+/// the `n + 1` wire encoding (CALL `returns` / VARARG `count`). `> 254` can't
+/// be encoded, so surface a graceful `Registers` error instead of an overflow.
+fn expand_count(n: usize) -> Result<u8, CompileError> {
+    u8::try_from(n)
+        .ok()
+        .filter(|&n| n < u8::MAX)
+        .ok_or_else(|| err(CompileErrorKind::Registers, LineNumber(0)))
+}
+
 /// Compile a `global` statement. There are three syntactic forms (see
 /// `manual.of:1655-1738` and upstream `lparser.c:1940-1977`):
 ///
@@ -1861,6 +1871,10 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
         .ok_or_else(|| ice("global stmt without star or targets"))?
         .collect();
     let values: Vec<Expr> = item.values().map(|v| v.collect()).unwrap_or_default();
+    // A parenthesized trailing `(f())` / `(...)` is adjusted to exactly one
+    // value, so it must NOT be expanded across the remaining targets. The
+    // `Expr` layer unwraps the paren node, so consult the raw syntax here.
+    let last_value_parenthesized = item.last_value_is_parenthesized();
 
     // Collect the declared names/kinds (reading the AST only). The
     // declarations don't take effect until *after* the initializers are
@@ -1893,7 +1907,31 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
     let value_base = ctx.chunk.freereg;
     if has_values {
         for (i, expr) in values.into_iter().enumerate() {
+            let is_last = i == n_values - 1;
             let want = RegisterIndex(value_base + i as u8);
+
+            // A trailing call/vararg expands across the remaining targets, but
+            // NOT when parenthesized (parens force exactly one value) — that
+            // falls through to the single-value path below.
+            if is_last && n_targets > n_values && !last_value_parenthesized {
+                if let Expr::FuncCall(call) = expr {
+                    let n = expand_count(n_targets - i)?;
+                    let regs = compile_expr_func_call(ctx, call, Want::Exact(n))?;
+                    debug_assert_eq!(regs[0].0, want.0);
+                    continue;
+                }
+                if let Expr::VarArg = expr {
+                    let n = expand_count(n_targets - i)?;
+                    let dst = ctx.reserve_regs(n)?;
+                    debug_assert_eq!(dst.0, want.0);
+                    ctx.emit(Instruction::VARARG {
+                        dst: dst.0,
+                        count: n + 1,
+                    });
+                    continue;
+                }
+            }
+
             let got = compile_expr_to_reg(ctx, expr, None)?;
             if got != want {
                 // Bare local/upvalue (or a mid-stack short-circuit result):

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -137,6 +137,7 @@ test!(global_const_star, "test-files/global_const_star.lua");
 test!(global_shadows_local, "test-files/global_shadows_local.lua");
 test_err!(global_self_init_err, "test-files/global_self_init_err.lua");
 test!(global_init_shadow, "test-files/global_init_shadow.lua");
+test!(global_multiret, "test-files/global_multiret.lua");
 test!(const_fold, "test-files/const_fold.lua");
 test!(const_no_fold, "test-files/const_no_fold.lua");
 test!(const_fold_branch, "test-files/const_fold_branch.lua");

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_multiret.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_multiret.snap
@@ -1,0 +1,152 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=7, upvalues=1)
+; constants:
+;   K0 = "a"
+;   K1 = "b"
+;   K2 = "print"
+;   K3 = 10
+;   K4 = 20
+;   K5 = 30
+;   K6 = 1
+;   K7 = nil
+;   K8 = "p"
+;   K9 = "q"
+;   K10 = "r"
+;   K11 = 7
+;   K12 = 8
+;   K13 = 9
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  CLOSURE         R0 P0
+0002  MOVE            R1 R0
+0003  CALL            R1 args=1 ret=3
+0004  GETTABUP        R3 U0 K0  ; "a"
+0005  ERRNNIL         R3 name=K0
+0006  SETTABUP        R1 U0 K0  ; "a"
+0007  GETTABUP        R3 U0 K1  ; "b"
+0008  ERRNNIL         R3 name=K1
+0009  SETTABUP        R2 U0 K1  ; "b"
+0010  GETTABUP        R1 U0 K2  ; "print"
+0011  GETTABUP        R2 U0 K0  ; "a"
+0012  GETTABUP        R3 U0 K1  ; "b"
+0013  CALL            R1 args=3 ret=1
+0014  CLOSURE         R1 P1
+0015  MOVE            R2 R1
+0016  LOAD            R3 K3  ; 10
+0017  LOAD            R4 K4  ; 20
+0018  LOAD            R5 K5  ; 30
+0019  CALL            R2 args=4 ret=1
+0020  LOAD            R2 K6  ; 1
+0021  LOAD            R3 K7  ; nil
+0022  LOAD            R4 K7  ; nil
+0023  GETTABUP        R5 U0 K8  ; "p"
+0024  ERRNNIL         R5 name=K8
+0025  SETTABUP        R2 U0 K8  ; "p"
+0026  GETTABUP        R5 U0 K9  ; "q"
+0027  ERRNNIL         R5 name=K9
+0028  SETTABUP        R3 U0 K9  ; "q"
+0029  GETTABUP        R5 U0 K10  ; "r"
+0030  ERRNNIL         R5 name=K10
+0031  SETTABUP        R4 U0 K10  ; "r"
+0032  GETTABUP        R2 U0 K2  ; "print"
+0033  GETTABUP        R3 U0 K8  ; "p"
+0034  GETTABUP        R4 U0 K9  ; "q"
+0035  GETTABUP        R5 U0 K10  ; "r"
+0036  CALL            R2 args=4 ret=1
+0037  CLOSURE         R2 P2
+0038  MOVE            R3 R2
+0039  LOAD            R4 K11  ; 7
+0040  LOAD            R5 K12  ; 8
+0041  LOAD            R6 K13  ; 9
+0042  CALL            R3 args=4 ret=1
+0043  RETURN          R0 count=1
+
+; prototype 0:
+  ; function (params=0, vararg=false, stack=2, upvalues=0)
+  ; constants:
+  ;   K0 = 10
+  ;   K1 = 20
+  ; code:
+  0000  LOAD            R0 K0  ; 10
+  0001  LOAD            R1 K1  ; 20
+  0002  RETURN          R0 count=3
+
+; prototype 1:
+  ; function (params=0, vararg=true, stack=4, upvalues=1)
+  ; constants:
+  ;   K0 = "x"
+  ;   K1 = "y"
+  ;   K2 = "z"
+  ;   K3 = "print"
+  ; upvalues:
+  ;   U0 = upvalue U0
+  ; code:
+  0000  VARARGPREP      fixed=0
+  0001  VARARG          R0 count=4
+  0002  GETTABUP        R3 U0 K0  ; "x"
+  0003  ERRNNIL         R3 name=K0
+  0004  SETTABUP        R0 U0 K0  ; "x"
+  0005  GETTABUP        R3 U0 K1  ; "y"
+  0006  ERRNNIL         R3 name=K1
+  0007  SETTABUP        R1 U0 K1  ; "y"
+  0008  GETTABUP        R3 U0 K2  ; "z"
+  0009  ERRNNIL         R3 name=K2
+  0010  SETTABUP        R2 U0 K2  ; "z"
+  0011  GETTABUP        R0 U0 K3  ; "print"
+  0012  GETTABUP        R1 U0 K0  ; "x"
+  0013  GETTABUP        R2 U0 K1  ; "y"
+  0014  GETTABUP        R3 U0 K2  ; "z"
+  0015  CALL            R0 args=4 ret=1
+  0016  RETURN          R0 count=1
+
+; prototype 2:
+  ; function (params=0, vararg=true, stack=4, upvalues=2)
+  ; constants:
+  ;   K0 = nil
+  ;   K1 = "s"
+  ;   K2 = "t"
+  ;   K3 = "print"
+  ;   K4 = "u"
+  ;   K5 = "v"
+  ;   K6 = "w"
+  ; upvalues:
+  ;   U0 = local R0
+  ;   U1 = upvalue U0
+  ; code:
+  0000  VARARGPREP      fixed=0
+  0001  GETUPVAL        R0 U0
+  0002  CALL            R0 args=1 ret=2
+  0003  LOAD            R1 K0  ; nil
+  0004  GETTABUP        R2 U1 K1  ; "s"
+  0005  ERRNNIL         R2 name=K1
+  0006  SETTABUP        R0 U1 K1  ; "s"
+  0007  GETTABUP        R2 U1 K2  ; "t"
+  0008  ERRNNIL         R2 name=K2
+  0009  SETTABUP        R1 U1 K2  ; "t"
+  0010  GETTABUP        R0 U1 K3  ; "print"
+  0011  GETTABUP        R1 U1 K1  ; "s"
+  0012  GETTABUP        R2 U1 K2  ; "t"
+  0013  CALL            R0 args=3 ret=1
+  0014  VARARG          R0 count=2
+  0015  LOAD            R1 K0  ; nil
+  0016  LOAD            R2 K0  ; nil
+  0017  GETTABUP        R3 U1 K4  ; "u"
+  0018  ERRNNIL         R3 name=K4
+  0019  SETTABUP        R0 U1 K4  ; "u"
+  0020  GETTABUP        R3 U1 K5  ; "v"
+  0021  ERRNNIL         R3 name=K5
+  0022  SETTABUP        R1 U1 K5  ; "v"
+  0023  GETTABUP        R3 U1 K6  ; "w"
+  0024  ERRNNIL         R3 name=K6
+  0025  SETTABUP        R2 U1 K6  ; "w"
+  0026  GETTABUP        R0 U1 K3  ; "print"
+  0027  GETTABUP        R1 U1 K4  ; "u"
+  0028  GETTABUP        R2 U1 K5  ; "v"
+  0029  GETTABUP        R3 U1 K6  ; "w"
+  0030  CALL            R0 args=4 ret=1
+  0031  RETURN          R0 count=1

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -258,6 +258,26 @@ impl Global {
         let expr_list = nodes.last()?;
         Some(expr_list.children().filter_map(Expr::cast))
     }
+
+    /// Whether the LAST initializer value is wrapped in parentheses.
+    /// `Expr::cast` transparently unwraps a `T![expr]` paren node, so a
+    /// trailing `(f())` / `(...)` is indistinguishable from a bare call /
+    /// vararg at the `Expr` level. The compiler needs this to suppress
+    /// multi-value expansion: parentheses adjust a multires expression to
+    /// exactly one value (`manual.of:2490-2493`).
+    pub fn last_value_is_parenthesized(&self) -> bool {
+        let mut nodes = self.0.children();
+        if nodes.next().is_none() {
+            return false;
+        }
+        let Some(expr_list) = nodes.last() else {
+            return false;
+        };
+        expr_list
+            .children()
+            .last()
+            .is_some_and(|node| node.kind() == T![expr])
+    }
 }
 
 ast_node!(GlobalTarget, T![global_target]);

--- a/test-files/global_multiret.lua
+++ b/test-files/global_multiret.lua
@@ -1,0 +1,23 @@
+global print
+local function f() return 10, 20 end
+global a, b = f()
+print(a, b)
+
+local function g(...)
+  global x, y, z = ...
+  print(x, y, z)
+end
+g(10, 20, 30)
+
+global p, q, r = 1
+print(p, q, r)
+
+-- Parentheses force exactly one value: the trailing (call)/(...) must NOT
+-- expand across the remaining targets, so the extras stay nil.
+local function h(...)
+  global s, t = (f())
+  print(s, t)
+  global u, v, w = (...)
+  print(u, v, w)
+end
+h(7, 8, 9)


### PR DESCRIPTION
## Summary

A `global` declaration whose last initializer is a multi-value producer (a function call or `...`) did not expand it across the remaining declaration targets — only the first value was captured and the rest were nil-padded. The analogous `local a, b = f()` already works, so this was specific to `compile_global`.

Before:
```
global print
local function f() return 10, 20 end
global a, b = f()
print(a, b)   -- lua: 10  20    tcvm (old): 10  nil
```

## Root cause

`compile_global`'s initializer loop compiled every RHS as a single result via `compile_expr_to_reg` and nil-padded beyond the value count, so a trailing call/vararg yielded only its first value. `compile_decl` (the local-decl path) already handled this: `Want::Exact` for a trailing `FuncCall`, reserve + `VARARG` for a trailing `VarArg`.

## Fix

- `compile_global`: for the LAST initializer when `n_targets > n_values`, expand a trailing producer just like `compile_decl` — `Expr::FuncCall` is compiled with `Want::Exact(n)`, `Expr::VarArg` reserves `n` slots and emits `VARARG { count: n + 1 }`, where `n = n_targets - i`. Materialized values land in the temp register block and are stored to each global exactly as the single-value path does.
- `expand_count` helper validates the `n + 1` wire encoding (`n < 255`), returning a graceful `CompileErrorKind::Registers` instead of a `u8` overflow on the changed path.
- `Global::last_value_is_parenthesized` (parser): a parenthesized trailing `(f())` / `(...)` is adjusted to exactly one value and must NOT expand. The `Expr` layer transparently unwraps the paren node, so the raw syntax is consulted to suppress expansion (`manual.of:2490-2493`).
- Fewer-values-than-targets without an expander (`global a, b, c = 1` → `1 nil nil`) still nil-pads; the recently-merged scoping/nil-pad fixes are preserved.

Scope: only the `global`-declaration multi-return expansion. `compile_assign`, parenthesized-truncation elsewhere, and method-call (`Expr::Method`) handling are untouched — see Remaining concerns.

## Verification

Reference: Lua 5.5.0 (PUC-Rio). All `tcvm` output below is byte-identical to `lua`.

Primary repro (`test-files/global_multiret.lua`):
```
10	20
10	20	30
1	nil	nil
10	nil          -- (f())  parenthesized: single value
7	nil	nil      -- (...)  parenthesized: single value
```

Edge cases (all `tcvm` == `lua`):
- `global a = f()` (single target, multi-ret call) → `a=10`
- `global c, d, e = f()` (f returns 2) → `10 20 nil`
- `global g, h = f(), 99` (trailing non-expander truncates f) → `10 99`
- `global x, y, z = ...` (vararg expander) → `10 20 30`

`N>=255` guard: a 256-target `global v0..v255 = ...` reports `compiler error at line 1: insufficient available registers` (no panic).

Snapshot bytecode confirms the encoding: `CALL ... ret=3` for `a,b=f()`; `VARARG ... count=4` for `x,y,z=...`; `LOAD;1` + 2x `LOAD;nil` for `p,q,r=1`; `CALL ... ret=2` + `LOAD nil` for `(f())`; `VARARG ... count=2` + 2x `LOAD nil` for `(...)`.

Build clean; `cargo fmt --all --check` clean; `cargo clippy` introduces no new lints in the changed regions (the two diagnostics it reports — `approx_constant` in `src/lua/mod.rs` and `needless_range_loop` in `compile_assign` — are pre-existing on `main` and outside this change).

## Tests

`cargo test --workspace` → 159 passed / 0 failed in the main suite (all other binaries + doctests pass). Adds:
- `test-files/global_multiret.lua` fixture (call/vararg expansion, nil-pad, parenthesized-single-value).
- `compiler::snapshot_tests::test_compile_global_multiret` snapshot.

All functional `test-files/global_*.lua` continue to match `lua` byte-for-byte.

## Remaining concerns (pre-existing, out of scope)

- A trailing method call `global m, n = t:m()` panics in the **cstree parser builder**, not in `compile_global`. Confirmed pre-existing and orthogonal: single-target `global m = t:m()`, the already-working `local m, n = t:m()`, and even a plain `x = t:m()` assignment all panic identically. Tracked as a separate parser follow-up.
- The `clippy approx_constant` deny-error in `src/lua/mod.rs:505` is a pre-existing `main` defect unrelated to this PR.

Closes #113
