### PR TITLE
compiler: adjust parenthesized expressions via an `Expr::Paren` node (alt to #118)

### DIFF
--- a/src/compiler/rules.rs
+++ b/src/compiler/rules.rs
@@ -1655,6 +1655,11 @@ fn compile_decl(ctx: &mut Ctx, item: Decl) -> Result<(), CompileError> {
                 assert_eq!(regs[0].0, expected);
                 continue;
             }
+            if let Expr::Method(call) = expr {
+                let want = (num_targets - i) as u8;
+                expand_method_call(ctx, call, RegisterIndex(expected), want)?;
+                continue;
+            }
             if let Expr::VarArg = expr {
                 let want = num_targets - i;
                 let dst = ctx.reserve_regs(want as u8)?;
@@ -1764,6 +1769,53 @@ fn compile_decl(ctx: &mut Ctx, item: Decl) -> Result<(), CompileError> {
 // ---------------------------------------------------------------------------
 // Lua 5.5 global declarations
 // ---------------------------------------------------------------------------
+
+/// Validate a trailing-multires expansion count for the `n+1` wire
+/// encoding used by `CALL.returns` / `VARARG.count`. The result count must
+/// fit in a `u8` after the `+1`, so `n` must be `< 255`; otherwise we'd
+/// silently overflow. Returns the count as `u8` on success.
+fn expand_count(n: usize) -> Result<u8, CompileError> {
+    if n >= u8::MAX as usize {
+        return Err(err(CompileErrorKind::Registers, LineNumber(0)));
+    }
+    Ok(n as u8)
+}
+
+/// Expand a trailing method-call initializer into `n` result registers at
+/// `[base, base + n)` for a `local`/`global` multi-target decl.
+///
+/// Unlike a plain `CALL` — whose func slot is forced to `freereg` (== `base`)
+/// by the call setup — a method call first evaluates the receiver. When the
+/// receiver is a temp it occupies `base`, so `SELF` lands the func one slot
+/// *above* `base` and the `CALL` results land at `[base + 1, ...)`. (When the
+/// receiver is an existing local below `base`, no temp is consumed and the
+/// results already land at `base`.) Detect the offset and MOVE the results
+/// down into `[base, base + n)` so the caller's nil-pad / SETTABUP loop —
+/// which keys off `base` and `freereg` — reads the right slots. Ascending
+/// order is collision-free since every destination is strictly below its
+/// source.
+fn expand_method_call(
+    ctx: &mut Ctx,
+    call: MethodCall,
+    base: RegisterIndex,
+    n: u8,
+) -> Result<(), CompileError> {
+    let regs = compile_expr_method_call(ctx, call, Want::Exact(n))?;
+    let landed = regs[0];
+    if landed.0 != base.0 {
+        debug_assert!(landed.0 > base.0);
+        for k in 0..n {
+            ctx.emit(Instruction::MOVE {
+                dst: base.0 + k,
+                src: landed.0 + k,
+            });
+        }
+        // Results now occupy `[base, base + n)`; reclaim the temp slots the
+        // receiver and the shifted call block left above.
+        ctx.chunk.freereg = base.0 + n;
+    }
+    Ok(())
+}
 
 /// Compile a `global` statement. There are three syntactic forms (see
 /// `manual.of:1655-1738` and upstream `lparser.c:1940-1977`):
@@ -1893,7 +1945,40 @@ fn compile_global(ctx: &mut Ctx, item: Global) -> Result<(), CompileError> {
     let value_base = ctx.chunk.freereg;
     if has_values {
         for (i, expr) in values.into_iter().enumerate() {
+            let is_last = i == n_values - 1;
             let want = RegisterIndex(value_base + i as u8);
+
+            // Last initializer supplies multiple values via a bare call or
+            // vararg: expand it across the remaining target slots, mirroring
+            // `compile_decl`. A parenthesized `(f())` / `(...)` is
+            // `Expr::Paren`, which doesn't match these arms — it falls
+            // through to the single-value path and adjusts to one value, so
+            // no per-site paren check is needed.
+            if is_last && n_targets > n_values {
+                let n = n_targets - i;
+                if let Expr::FuncCall(call) = expr {
+                    let n = expand_count(n)?;
+                    let regs = compile_expr_func_call(ctx, call, Want::Exact(n))?;
+                    debug_assert_eq!(regs[0].0, want.0);
+                    continue;
+                }
+                if let Expr::Method(call) = expr {
+                    let n = expand_count(n)?;
+                    expand_method_call(ctx, call, want, n)?;
+                    continue;
+                }
+                if let Expr::VarArg = expr {
+                    let n = expand_count(n)?;
+                    let dst = ctx.reserve_regs(n)?;
+                    debug_assert_eq!(dst.0, want.0);
+                    ctx.emit(Instruction::VARARG {
+                        dst: dst.0,
+                        count: n + 1,
+                    });
+                    continue;
+                }
+            }
+
             let got = compile_expr_to_reg(ctx, expr, None)?;
             if got != want {
                 // Bare local/upvalue (or a mid-stack short-circuit result):
@@ -2342,6 +2427,7 @@ fn expr_reads(ctx: &Ctx, expr: &Expr, reg: u8) -> Result<bool, CompileError> {
             }
             false
         }
+        Expr::Paren(inner) => expr_reads(ctx, inner, reg)?,
     })
 }
 
@@ -2512,6 +2598,14 @@ fn compile_expr(
             });
             Ok(ExprDesc::from_reg(dst))
         }
+        // Transparent recurse: the paren only matters at multi-value
+        // expansion sites (which match the concrete FuncCall/Method/VarArg
+        // variants, so a Paren wrapper there naturally adjusts to one
+        // value). For single-value compilation it has no effect, so we
+        // return the inner ExprDesc unchanged WITHOUT forcing a register
+        // discharge — discharging here would run before const-folding and
+        // short-circuit/jump lowering and defeat them for every `(expr)`.
+        Expr::Paren(inner) => compile_expr(ctx, *inner, dst),
     }
 }
 
@@ -3828,10 +3922,11 @@ fn compile_return(ctx: &mut Ctx, item: Return) -> Result<(), CompileError> {
     // exactly one return expression, directly a call. Matches Lua 5.5's
     // tail-call rule.
     //
-    // See #48: Lua 5.5 does NOT tail-call parenthesised `return (f())`
-    // because the parens force adjust-to-one. The parser here doesn't
-    // surface a distinct paren node, so we over-eagerly tail-call that
-    // form for now.
+    // Per #48, Lua 5.5 does NOT tail-call parenthesised `return (f())`
+    // because the parens force adjust-to-one. The parser preserves the
+    // paren as `Expr::Paren`, which doesn't match the FuncCall/Method
+    // arms here, so it falls through to `compile_return_generic` and
+    // correctly returns a single value (`manual.of:1573`).
     if exprs.len() == 1 {
         let only = exprs.pop().unwrap();
         match only {

--- a/src/compiler/snapshot_tests.rs
+++ b/src/compiler/snapshot_tests.rs
@@ -156,3 +156,8 @@ test!(not_andor, "test-files/not_andor.lua");
 test!(jmp_elim, "test-files/jmp_elim.lua");
 test!(if_empty_nested, "test-files/if_empty_nested.lua");
 test!(if_empty_goto, "test-files/if_empty_goto.lua");
+test!(paren_adjust, "test-files/paren_adjust.lua");
+test!(
+    global_multiret_expand,
+    "test-files/global_multiret_expand.lua"
+);

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_multiret_expand.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_global_multiret_expand.snap
@@ -1,0 +1,163 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=5, upvalues=1)
+; constants:
+;   K0 = 100
+;   K1 = 200
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  CLOSURE         R0 P0
+0002  CLOSURE         R1 P1
+0003  MOVE            R2 R1
+0004  LOAD            R3 K0  ; 100
+0005  LOAD            R4 K1  ; 200
+0006  CALL            R2 args=3 ret=1
+0007  RETURN          R0 count=1
+
+; prototype 0:
+  ; function (params=0, vararg=false, stack=2, upvalues=0)
+  ; constants:
+  ;   K0 = 10
+  ;   K1 = 20
+  ; code:
+  0000  LOAD            R0 K0  ; 10
+  0001  LOAD            R1 K1  ; 20
+  0002  RETURN          R0 count=3
+
+; prototype 1:
+  ; function (params=0, vararg=true, stack=14, upvalues=2)
+  ; constants:
+  ;   K0 = "a"
+  ;   K1 = "b"
+  ;   K2 = nil
+  ;   K3 = "c"
+  ;   K4 = "d"
+  ;   K5 = "e"
+  ;   K6 = "g"
+  ;   K7 = "h"
+  ;   K8 = "i"
+  ;   K9 = "m"
+  ;   K10 = "j"
+  ;   K11 = "k"
+  ;   K12 = "l"
+  ;   K13 = "n"
+  ;   K14 = "print"
+  ; upvalues:
+  ;   U0 = local R0
+  ;   U1 = upvalue U0
+  ; code:
+  0000  VARARGPREP      fixed=0
+  0001  GETUPVAL        R0 U0
+  0002  CALL            R0 args=1 ret=3
+  0003  GETTABUP        R2 U1 K0  ; "a"
+  0004  ERRNNIL         R2 name=K0
+  0005  SETTABUP        R0 U1 K0  ; "a"
+  0006  GETTABUP        R2 U1 K1  ; "b"
+  0007  ERRNNIL         R2 name=K1
+  0008  SETTABUP        R1 U1 K1  ; "b"
+  0009  GETUPVAL        R0 U0
+  0010  CALL            R0 args=1 ret=2
+  0011  LOAD            R1 K2  ; nil
+  0012  GETTABUP        R2 U1 K3  ; "c"
+  0013  ERRNNIL         R2 name=K3
+  0014  SETTABUP        R0 U1 K3  ; "c"
+  0015  GETTABUP        R2 U1 K4  ; "d"
+  0016  ERRNNIL         R2 name=K4
+  0017  SETTABUP        R1 U1 K4  ; "d"
+  0018  VARARG          R0 count=3
+  0019  GETTABUP        R2 U1 K5  ; "e"
+  0020  ERRNNIL         R2 name=K5
+  0021  SETTABUP        R0 U1 K5  ; "e"
+  0022  GETTABUP        R2 U1 K6  ; "g"
+  0023  ERRNNIL         R2 name=K6
+  0024  SETTABUP        R1 U1 K6  ; "g"
+  0025  VARARG          R0 count=2
+  0026  LOAD            R1 K2  ; nil
+  0027  GETTABUP        R2 U1 K7  ; "h"
+  0028  ERRNNIL         R2 name=K7
+  0029  SETTABUP        R0 U1 K7  ; "h"
+  0030  GETTABUP        R2 U1 K8  ; "i"
+  0031  ERRNNIL         R2 name=K8
+  0032  SETTABUP        R1 U1 K8  ; "i"
+  0033  NEWTABLE        R0
+  0034  CLOSURE         R1 P0
+  0035  SETFIELD        R1 R0 K9  ; "m"
+  0036  SELF            R1 R0 K9  ; "m"
+  0037  CALL            R1 args=2 ret=3
+  0038  GETTABUP        R3 U1 K10  ; "j"
+  0039  ERRNNIL         R3 name=K10
+  0040  SETTABUP        R1 U1 K10  ; "j"
+  0041  GETTABUP        R3 U1 K11  ; "k"
+  0042  ERRNNIL         R3 name=K11
+  0043  SETTABUP        R2 U1 K11  ; "k"
+  0044  SELF            R1 R0 K9  ; "m"
+  0045  CALL            R1 args=2 ret=2
+  0046  LOAD            R2 K2  ; nil
+  0047  GETTABUP        R3 U1 K12  ; "l"
+  0048  ERRNNIL         R3 name=K12
+  0049  SETTABUP        R1 U1 K12  ; "l"
+  0050  GETTABUP        R3 U1 K13  ; "n"
+  0051  ERRNNIL         R3 name=K13
+  0052  SETTABUP        R2 U1 K13  ; "n"
+  0053  GETTABUP        R1 U1 K14  ; "print"
+  0054  GETTABUP        R2 U1 K0  ; "a"
+  0055  GETTABUP        R3 U1 K1  ; "b"
+  0056  GETTABUP        R4 U1 K3  ; "c"
+  0057  GETTABUP        R5 U1 K4  ; "d"
+  0058  GETTABUP        R6 U1 K5  ; "e"
+  0059  GETTABUP        R7 U1 K6  ; "g"
+  0060  GETTABUP        R8 U1 K7  ; "h"
+  0061  GETTABUP        R9 U1 K8  ; "i"
+  0062  GETTABUP        R10 U1 K10  ; "j"
+  0063  GETTABUP        R11 U1 K11  ; "k"
+  0064  GETTABUP        R12 U1 K12  ; "l"
+  0065  GETTABUP        R13 U1 K13  ; "n"
+  0066  CALL            R1 args=13 ret=1
+  0067  CLOSURE         R1 P1
+  0068  MOVE            R2 R1
+  0069  CALL            R2 args=1 ret=1
+  0070  RETURN          R0 count=1
+
+  ; prototype 0:
+    ; function (params=1, vararg=false, stack=3, upvalues=0)
+    ; constants:
+    ;   K0 = 10
+    ;   K1 = 20
+    ; code:
+    0000  LOAD            R1 K0  ; 10
+    0001  LOAD            R2 K1  ; 20
+    0002  RETURN          R1 count=3
+
+  ; prototype 1:
+    ; function (params=0, vararg=false, stack=4, upvalues=2)
+    ; constants:
+    ;   K0 = "m"
+    ;   K1 = "o"
+    ;   K2 = "p"
+    ;   K3 = "print"
+    ;   K4 = "up_recv"
+    ; upvalues:
+    ;   U0 = local R0
+    ;   U1 = upvalue U1
+    ; code:
+    0000  GETUPVAL        R0 U0
+    0001  SELF            R1 R0 K0  ; "m"
+    0002  CALL            R1 args=2 ret=3
+    0003  MOVE            R0 R1
+    0004  MOVE            R1 R2
+    0005  GETTABUP        R2 U1 K1  ; "o"
+    0006  ERRNNIL         R2 name=K1
+    0007  SETTABUP        R0 U1 K1  ; "o"
+    0008  GETTABUP        R2 U1 K2  ; "p"
+    0009  ERRNNIL         R2 name=K2
+    0010  SETTABUP        R1 U1 K2  ; "p"
+    0011  GETTABUP        R0 U1 K3  ; "print"
+    0012  LOAD            R1 K4  ; "up_recv"
+    0013  GETTABUP        R2 U1 K1  ; "o"
+    0014  GETTABUP        R3 U1 K2  ; "p"
+    0015  CALL            R0 args=4 ret=1
+    0016  RETURN          R0 count=1

--- a/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_paren_adjust.snap
+++ b/src/compiler/snapshots/tcvm__compiler__snapshot_tests__compile_paren_adjust.snap
@@ -1,0 +1,115 @@
+---
+source: src/compiler/snapshot_tests.rs
+expression: output
+---
+; function (params=0, vararg=true, stack=26, upvalues=1)
+; constants:
+;   K0 = nil
+;   K1 = "meth"
+; upvalues:
+;   U0 = local R0
+; code:
+0000  VARARGPREP      fixed=0
+0001  CLOSURE         R0 P0
+0002  MOVE            R1 R0
+0003  CALL            R1 args=1 ret=3
+0004  MOVE            R3 R0
+0005  CALL            R3 args=1 ret=2
+0006  LOAD            R4 K0  ; nil
+0007  NEWTABLE        R5
+0008  CLOSURE         R6 P1
+0009  SETFIELD        R6 R5 K1  ; "meth"
+0010  SELF            R6 R5 K1  ; "meth"
+0011  CALL            R6 args=2 ret=3
+0012  SELF            R8 R5 K1  ; "meth"
+0013  CALL            R8 args=2 ret=2
+0014  LOAD            R9 K0  ; nil
+0015  CLOSURE         R10 P2
+0016  CLOSURE         R11 P3
+0017  CLOSURE         R12 P4
+0018  CLOSURE         R13 P5
+0019  MOVE            R14 R1
+0020  MOVE            R15 R2
+0021  MOVE            R16 R3
+0022  MOVE            R17 R4
+0023  MOVE            R18 R6
+0024  MOVE            R19 R7
+0025  MOVE            R20 R8
+0026  MOVE            R21 R9
+0027  MOVE            R22 R11
+0028  MOVE            R23 R12
+0029  MOVE            R24 R13
+0030  MOVE            R25 R10
+0031  RETURN          R14 count=13
+
+; prototype 0:
+  ; function (params=0, vararg=false, stack=2, upvalues=0)
+  ; constants:
+  ;   K0 = 10
+  ;   K1 = 20
+  ; code:
+  0000  LOAD            R0 K0  ; 10
+  0001  LOAD            R1 K1  ; 20
+  0002  RETURN          R0 count=3
+
+; prototype 1:
+  ; function (params=1, vararg=false, stack=3, upvalues=0)
+  ; constants:
+  ;   K0 = 10
+  ;   K1 = 20
+  ; code:
+  0000  LOAD            R1 K0  ; 10
+  0001  LOAD            R2 K1  ; 20
+  0002  RETURN          R1 count=3
+
+; prototype 2:
+  ; function (params=0, vararg=false, stack=4, upvalues=1)
+  ; constants:
+  ;   K0 = "meth"
+  ; upvalues:
+  ;   U0 = local R5
+  ; code:
+  0000  GETUPVAL        R0 U0
+  0001  SELF            R1 R0 K0  ; "meth"
+  0002  CALL            R1 args=2 ret=3
+  0003  MOVE            R0 R1
+  0004  MOVE            R1 R2
+  0005  MOVE            R2 R0
+  0006  MOVE            R3 R1
+  0007  RETURN          R2 count=3
+
+; prototype 3:
+  ; function (params=0, vararg=true, stack=12, upvalues=0)
+  ; constants:
+  ;   K0 = nil
+  ; code:
+  0000  VARARGPREP      fixed=0
+  0001  VARARG          R0 count=3
+  0002  VARARG          R2 count=2
+  0003  LOAD            R3 K0  ; nil
+  0004  VARARG          R4 count=2
+  0005  LOAD            R5 K0  ; nil
+  0006  MOVE            R6 R0
+  0007  MOVE            R7 R1
+  0008  MOVE            R8 R2
+  0009  MOVE            R9 R3
+  0010  MOVE            R10 R4
+  0011  MOVE            R11 R5
+  0012  RETURN          R6 count=7
+
+; prototype 4:
+  ; function (params=0, vararg=false, stack=1, upvalues=1)
+  ; upvalues:
+  ;   U0 = local R0
+  ; code:
+  0000  GETUPVAL        R0 U0
+  0001  CALL            R0 args=1 ret=2
+  0002  RETURN          R0 count=2
+
+; prototype 5:
+  ; function (params=0, vararg=false, stack=1, upvalues=1)
+  ; upvalues:
+  ;   U0 = local R0
+  ; code:
+  0000  GETUPVAL        R0 U0
+  0001  TAILCALL        R0 args=1

--- a/src/parser/syntax.rs
+++ b/src/parser/syntax.rs
@@ -123,6 +123,10 @@ pub enum Expr {
     FuncCall(FuncCall),
     Index(Index),
     VarArg,
+    /// A parenthesized expression `(e)`. Preserved (rather than unwrapped)
+    /// because the parens force a multi-value expression to adjust to one
+    /// value, e.g. `local a, b = (f())` binds `b` to nil (`manual.of:1573`).
+    Paren(Box<Expr>),
 }
 
 impl Expr {
@@ -137,7 +141,10 @@ impl Expr {
             T![bin_op] => BinaryOp::cast(node).map(Self::BinaryOp)?,
             T![func_call] => FuncCall::cast(node).map(Self::FuncCall)?,
             T![index] => Index::cast(node).map(Self::Index)?,
-            T![expr] => node.first_child().and_then(Expr::cast)?,
+            T![expr] => {
+                let inner = node.first_child().and_then(Expr::cast)?;
+                Self::Paren(Box::new(inner))
+            }
             T![literal_expr] => Literal::cast(node).map(Self::Literal)?,
             _ => return None,
         })

--- a/test-files/global_multiret_expand.lua
+++ b/test-files/global_multiret_expand.lua
@@ -1,0 +1,40 @@
+-- `global a, b = <multi>` expands a trailing call/vararg across targets
+-- (#113); a parenthesized trailing value adjusts to one and is nil-padded.
+global print
+
+local function f()
+  return 10, 20
+end
+
+local function w(...)
+  -- Bare call expands: a=10, b=20 (CALL ret=3 + 2x SETTABUP).
+  global a, b = f()
+  -- Parenthesized call adjusts to one: c=10, d=nil (CALL ret=2 + LOADNIL).
+  global c, d = (f())
+  -- Bare vararg expands (VARARG count=3).
+  global e, g = ...
+  -- Parenthesized vararg adjusts to one (VARARG count=2 + LOADNIL).
+  global h, i = (...)
+  -- Bare method call expands: j=10, k=20 (SELF + CALL ret=3 + 2x SETTABUP).
+  local t = {}
+  t.m = function(self)
+    return 10, 20
+  end
+  global j, k = t:m()
+  -- Parenthesized method call adjusts to one: l=10, m=nil.
+  global l, n = (t:m())
+  print(a, b, c, d, e, g, h, i, j, k, l, n)
+  -- Method-call expander where the receiver is an UPVALUE inside a nested
+  -- function whose value-block base is R0: SELF lands the func above the
+  -- receiver temp, so the expander MOVEs the results down to R0/R1.
+  -- The `global` decl is lexically scoped to `up_recv`; print there too.
+  -- (Ordered after the outer print on purpose — declaring new `o`/`p`
+  -- globals transitions `_ENV`'s shape.)
+  local function up_recv()
+    global o, p = t:m()
+    print("up_recv", o, p)
+  end
+  up_recv()
+end
+
+w(100, 200)

--- a/test-files/paren_adjust.lua
+++ b/test-files/paren_adjust.lua
@@ -1,0 +1,50 @@
+-- Parenthesized multi-value RHS adjusts to one value (#119, #48); bare
+-- trailing call/vararg still expands across targets.
+local function f()
+  return 10, 20
+end
+
+-- Bare call expands: a=10, b=20 (CALL ret=3).
+local a, b = f()
+
+-- Parenthesized call adjusts to one: c=10, d=nil (CALL ret=2 + LOADNIL).
+local c, d = (f())
+
+-- Bare method call expands: m=10, n=20 (SELF + CALL ret=3).
+local tbl = {}
+tbl.meth = function(self)
+  return 10, 20
+end
+local m, n = tbl:meth()
+-- Parenthesized method call adjusts to one: o=10, p=nil.
+local o, p = (tbl:meth())
+
+-- Method-call expander with the receiver as an UPVALUE inside a nested
+-- function whose value-block base is R0: SELF lands the func above the
+-- receiver temp, so the expander must MOVE the results down to R0/R1.
+local function up_recv()
+  local x, y = tbl:meth()
+  return x, y
+end
+
+local function g(...)
+  -- Bare vararg expands (VARARG count=3).
+  local p, q = ...
+  -- Parenthesized vararg adjusts to one (VARARG count=2 + LOADNIL).
+  local r, s = (...)
+  -- Nested parens still adjust to one.
+  local t, u = ((...))
+  return p, q, r, s, t, u
+end
+
+-- `return (f())` must NOT tail-call; adjust to one value (CALL + RETURN).
+local function h()
+  return (f())
+end
+
+-- Bare `return f()` still tail-calls.
+local function k()
+  return f()
+end
+
+return a, b, c, d, m, n, o, p, g, h, k, up_recv


### PR DESCRIPTION
## Summary

Fixes the whole "parenthesized multires adjust-to-one + trailing multires expansion" bug class **uniformly** by introducing a real `Expr::Paren` AST node, rather than a per-site paren check.

This closes:
- **#113** — `global a, b = f()` / `= ...` now EXPAND a trailing multi-return RHS across targets; `global a, b = (f())` / `= (...)` adjust to one value (`10 nil`).
- **#119** — the same paren adjust-to-one for LOCAL decls: `local a, b = (f())` / `= (...)` -> `10 nil` (bare `local a, b = f()` still expands -> `10 20`).
- **#48 (paren-return case)** — `return (f())` no longer tail-calls; it adjusts to one value.

## Root cause

Lua 5.5 forces a parenthesized multi-value expression to adjust to exactly one value (`manual.of:1573`). But `Expr::cast` UNWRAPPED the paren node:

```rust
T![expr] => node.first_child().and_then(Expr::cast)?,
```

so a trailing `(f())` was indistinguishable from a bare `f()` at the `Expr` level. Every multi-value expansion site (decl, global, return, args, table ctor) then treated `(f())` / `(...)` / `(t:m())` as multi-return.

## Approach: `Expr::Paren`, transparent recurse

1. `Expr::cast` now PRESERVES the paren as `Expr::Paren(Box<Expr>)`.
2. `compile_expr` handles it by recursing **transparently** into the inner expr and returning its `ExprDesc` unchanged:
   ```rust
   Expr::Paren(inner) => compile_expr(ctx, *inner, dst),
   ```
   It does **NOT** discharge the inner to a register — that would run before const-folding and short-circuit/jump lowering and defeat them for every `(expr)`.
3. Adjust-to-one then falls out for free: multi-value sites match the concrete `Expr::FuncCall` / `Expr::Method` / `Expr::VarArg` variants, which an `Expr::Paren` wrapper no longer matches, so it drops to the single-value path.
4. `compile_global` gains the trailing-multires expander (FuncCall / Method / VarArg), mirroring `compile_decl`, plus an `expand_count` overflow guard. The shared `expand_method_call` helper MOVEs results down when SELF lands the func above the value base (correct even at base register 0).

The exhaustive `Expr` matches (`compile_expr`, `expr_reads`) handle the new variant; non-exhaustive `if let Expr::X` sites need no change (a `Paren` simply doesn't match, which IS the desired adjust-to-one).

## What it fixes (vs Lua 5.5.0)

| case | expected | result |
|---|---|---|
| `global a,b = f()` / `= ...` / `= t:m()` (#113) | `10 20` | MATCH |
| `global a,b = (f())` / `= (...)` / `= (t:m())` (#113) | `10 nil` | MATCH |
| `local a,b = (f())` / `= (...)` / `= (t:m())` (#119) | `10 nil` | MATCH |
| `local a,b = f()` / `= ...` (bare, still expands) | `10 20` | MATCH |
| `return (f())` / `return (...)` (#48) | `10` (no tail-call) | MATCH |
| `return f()` / `return ...` (bare, still tail-calls) | `10 20` | MATCH |
| bonus: `f((g()))`, `#{(g())}` (args / table ctor) | adjust-to-one | MATCH |

## Verification (real output)

- `cargo build -p tcvm-cli` — Finished, no errors.
- `cargo fmt --all --check` — clean.
- `cargo test --workspace` — 241 passed, 0 failed; no `.snap.new`.
- **Snapshots unchanged (load-bearing):** the 5 optimization snapshots (`const_fold`, `logic`, `not_andor`, `jmp_elim`, `short_circuit_local_clobber`) are byte-identical vs `main` (`git diff --name-only HEAD -- 'src/compiler/snapshots/*.snap'` is empty); only two new fixtures are added. Spot-check via `tcvm-cli -l`: `local x = (1 + 2)` still folds to `LOAD R0 K0 ; 3` and `(true and 5) or 6` still lowers to TEST/JMP — proving the Paren arm is a transparent recurse, not a discharge.
- Every paren/bare case above was diffed against Lua 5.5.0 and MATCHES.
- The two new fixtures exercise a `value_base == 0` method expander (receiver as an upvalue in a nested fn); the snapshot captures `SELF R1 R0` then `MOVE R0 R1; MOVE R1 R2` as regression coverage for the down-MOVE.
- `cargo clippy --workspace` is clean (warnings only). `--all-targets` surfaces one pre-existing `approx_constant` deny in `src/lua/mod.rs` (a test this PR does not touch — verified identical on clean base HEAD).

## Alternative to #118

This is an alternative to #118. Where #118 adds a `Global::last_value_is_parenthesized()` raw-syntax probe scoped to `global` declarations (FuncCall + VarArg only), this PR fixes the class once at the AST layer, so it ALSO covers local decls (#119), `return (f())` (#48), method-call expansion, and argument/table-constructor positions, with no codegen regression.

Closes #113
Closes #119
