### PR TITLE
vm: restore caller register window on Lua-frame return (nested native call clobbered caller locals)

### DIFF
--- a/src/vm/interp.rs
+++ b/src/vm/interp.rs
@@ -2671,6 +2671,15 @@ pub(crate) fn frame_return<'gc>(
     let caller = thread.top_lua().unwrap();
     let new_base = caller.base;
     let new_ip = unsafe { caller.closure.proto.code.as_ptr().add(caller.pc) };
+    // A native call in the returning frame (or a nested callee) may have
+    // truncated the shared stack to its own window. Restore the caller's full
+    // register window before resuming, or register writes through the raw
+    // `registers` pointer land in the Vec's spare capacity (beyond `len`) and a
+    // later `resize` nils them.
+    let needed = new_base + caller.closure.proto.max_stack_size as usize;
+    if thread.stack.len() < needed {
+        thread.stack.resize(needed, Value::nil());
+    }
     FrameReturn::Caller { new_base, new_ip }
 }
 

--- a/tests/native_call_nested_stack.rs
+++ b/tests/native_call_nested_stack.rs
@@ -1,0 +1,89 @@
+//! Regression: a native call made from inside a *nested* function truncated the
+//! shared thread stack down to the native's argument window, and the return
+//! path back into the caller (`frame_return`'s `Caller` branch) did not restore
+//! the caller's full register window. The caller then resumed with
+//! `stack.len() <` its window, so register writes through the raw `registers`
+//! pointer landed in the Vec's spare capacity (past `len`) and the next native
+//! call's `resize` nilled them — silently clobbering the caller's locals (and
+//! globals loaded into registers) above the nested-call slot.
+//!
+//! Every expectation is checked against `lua` 5.5.0.
+
+use tcvm::{Executor, LoadError, Lua};
+
+fn eval_bool(src: &str) -> bool {
+    let mut lua = Lua::new();
+    lua.load_all();
+    let ex = lua
+        .try_enter(|ctx| -> Result<_, LoadError> {
+            let chunk = ctx.load(src, Some("native_call_nested_stack"))?;
+            Ok(ctx.stash(Executor::start(ctx, chunk, ())))
+        })
+        .expect("load");
+    lua.execute::<bool>(&ex).expect("run")
+}
+
+#[test]
+fn nested_native_call_preserves_caller_locals() {
+    // `up()` calls a native (`type`); `w`'s locals declared before `up` must
+    // survive the call. Pre-fix, `lc` came back nil.
+    assert!(eval_bool(
+        "local type = type\n\
+         local function w()\n\
+           local la, lb, lc = 11, 22, 33\n\
+           local function up() local _ = type(nil) end\n\
+           up()\n\
+           return la == 11 and lb == 22 and lc == 33\n\
+         end\n\
+         return w()"
+    ));
+}
+
+#[test]
+fn four_locals_survive_nested_native_call() {
+    assert!(eval_bool(
+        "local type = type\n\
+         local function w()\n\
+           local a, b, c, d = 1, 2, 3, 4\n\
+           local function up() local _ = type(nil) end\n\
+           up()\n\
+           return a == 1 and b == 2 and c == 3 and d == 4\n\
+         end\n\
+         return w()"
+    ));
+}
+
+#[test]
+fn caller_survives_when_native_called_before_and_after_grow() {
+    // Native call inside `up` both before and after it grows its own window;
+    // exercises a couple of truncate/restore round-trips before `w` resumes.
+    assert!(eval_bool(
+        "local type = type\n\
+         local function w()\n\
+           local a, b, c, d, e = 5, 6, 7, 8, 9\n\
+           local function up() local _ = type(nil); local _ = type(type(1)) end\n\
+           up()\n\
+           return a == 5 and b == 6 and c == 7 and d == 8 and e == 9\n\
+         end\n\
+         return w()"
+    ));
+}
+
+#[test]
+fn nested_global_decl_then_native_keeps_outer_globals() {
+    // The symptom this was first noticed through: a nested function declares new
+    // globals and makes a native call; the outer function's earlier globals must
+    // still read back correctly afterward.
+    assert!(eval_bool(
+        "global print\n\
+         local function w()\n\
+           global a, b = 1, 2\n\
+           global c, d = 3, 4\n\
+           global e, g = 5, 6\n\
+           local function up() global oo, pp = 77, 88; print(oo, pp) end\n\
+           up()\n\
+           return a == 1 and b == 2 and c == 3 and d == 4 and e == 5 and g == 6\n\
+         end\n\
+         return w()"
+    ));
+}


### PR DESCRIPTION
## Summary

A native (Rust) call made from inside a **nested** Lua function could silently clobber the **calling** function's locals (and globals it had loaded into registers), reading them back as `nil`. Found while investigating a report of `_ENV` globals reading `nil` after a nested `global` declaration — that turned out to be a special case of this stack bug, not a GC or `_ENV` issue.

## Repro (vs `lua` 5.5.0)

```lua
local type = type
local function w()
  local la, lb, lc = 11, 22, 33
  local function up() local _ = type(nil) end   -- native call in a nested fn
  up()
  print(la, lb, lc)        -- lua: 11 22 33    tcvm (pre-fix): 11 22 nil
end
w()
```

## Root cause

`invoke_native` truncates the shared thread stack to the native's argument window (`thread.stack.truncate(args_base + argc)`). When the native is called from a nested frame, that truncation leaves the stack shorter than an **outer** frame's register window. `frame_return`'s `Caller` branch then resumed the caller *without* re-growing the stack to `caller.base + caller.proto.max_stack_size`.

Running with `stack.len()` below its window, the caller's register writes through the raw `registers` pointer (e.g. `MOVE`ing a local into a call-arg slot) land in the `Vec`'s spare **capacity** past `len`. The next native call's `resize(.., nil)` fills those slots with `nil`, clobbering the values.

Traced concretely on the minimal repro (`w_base=5`, `la/lb/lc` at indices 5/6/7):
- `up()`'s `type(nil)` truncates the stack 13 → 12 (to `type`'s window).
- `up` returns to `w`; `w`'s window is `base(5) + max_stack(8) = 13`, but the stack stays at `len=12`.
- `w` resumes, `MOVE`s `lc` into `R7` = index 12 (spare capacity, past `len`).
- `print`'s `invoke_native` does `resize(13, nil)` → index 12 becomes `nil`, so `print` reads `11, 22, nil`.

## Fix

Restore the caller's full register window in `frame_return` before returning `Caller`:

```rust
let needed = new_base + caller.closure.proto.max_stack_size as usize;
if thread.stack.len() < needed {
    thread.stack.resize(needed, Value::nil());
}
```

This mirrors the window-restore the native-return path in `op_call` already does for its immediate `top_lua` frame; the gap was the subsequent Lua-frame return.

## Verification

- New `tests/native_call_nested_stack.rs` (4 cases: 3 / 4 / 5 caller locals, and the nested-`global` symptom) — all green, checked against `lua` 5.5.0.
- The original `_ENV` symptom (`global a,b…` then a nested `global o,p` + native call) now matches `lua`.
- `cargo test --workspace`: **245 passed, 0 failed**. `cargo fmt --all --check` clean. `cargo clippy --workspace` clean (only the pre-existing `thread`/`ip` unused-arg warnings, present on `main`).

**Severity: correctness** — any nested helper that calls a stdlib native (`print`, `math.*`, `type`, …) could silently nil out the caller's live locals above the call site.
